### PR TITLE
Workflow improvements: per-direction analysis review, count-drift sweep, checklist sync, commit/PR discipline

### DIFF
--- a/workflows/gap-analysis.md
+++ b/workflows/gap-analysis.md
@@ -46,13 +46,26 @@ graph TD
         E2 -->|Yes| E4
     end
 
-    P1 --> P2 --> P3 --> P4 --> P5
+    subgraph P6["Phase 6: Commit & Push"]
+        F1["Stage research files only<br/>(explicit paths, not git add -A)"]
+        F2["Commit on master with<br/>descriptive ingest message"]
+        F3["Push master to origin"]
+        F4{"Workflow files<br/>also touched?"}
+        F5["Branch + commit + push;<br/>open PR for workflow changes"]
+        F1 --> F2 --> F3 --> F4
+        F4 -->|Yes| F5
+        F4 -->|No| Done([Done])
+        F5 --> Done
+    end
+
+    P1 --> P2 --> P3 --> P4 --> P5 --> P6
 
     style P1 fill:#dae8fc,stroke:#6c8ebf
     style P2 fill:#fff2cc,stroke:#d6b656
     style P3 fill:#d5e8d4,stroke:#82b366
     style P4 fill:#ffe6cc,stroke:#d79b00
     style P5 fill:#e1d5e7,stroke:#9673a6
+    style P6 fill:#f8cecc,stroke:#b85450
 ```
 
 ## Purpose
@@ -177,12 +190,40 @@ For single-paper ingests, triggers 2-4 always fire; trigger 1 fires conditionall
    - Source page depth — does it meet the depth standard?
    - Entity creation — if a new entity was needed, was it created at full depth?
    - Concept/source/MOC propagation — were all relevant pages updated with substantive content (not just link additions)?
-   - Analysis updates — were all 5+ living analyses checked and updated where relevant?
+   - Analysis updates — were all 6+ living analyses checked, *and was each numbered direction in `frontier-research-directions.md` and each numbered tension in `contradictions.md` reviewed individually*?
    - Overview / README / log — were the global pages updated?
+   - **Count-drift discipline** — was the stale paper-count sweep performed (`workflows/ingest.md` step 11)? Were all hardcoded counts in body prose (intros, methodology paragraphs, MOC blurbs, blind-spot bullets, README badges, README per-thread headers, `wiki/index.md` directory tree) updated to the new value? Score 0/10 if any count outside `wiki/log.md` still shows the old value.
    - Lint compliance — do all new links resolve, do all new anchors exist?
    - Workflow trigger discipline — were all downstream workflow triggers explicitly checked and acted on?
 2. **If < 10/10**: Identify the missing pieces, fix them, and re-grade. Iterate until 10/10. Do not skip this loop — it is the difference between a 7/10 ingest and a 10/10 ingest.
 3. **Append a final summary** to `wiki/log.md` with the gap statement, the chosen paper, the propagation summary, and the final grade.
+
+### Phase 6: Commit and Push (Research) + PR (Workflow Changes)
+
+This phase exists because uncommitted ingest work is fragile (it can be lost to a tab crash, an accidental `git restore`, or a context-window reset on the next session) and because workflow changes deserve explicit review even when research changes are routine. The split is based on **blast radius**: research files are content-only and reviewed continuously by the user, so they ship straight to `master`; workflow files change *how future ingests are run* and benefit from a PR review surface.
+
+1. **Identify which files belong to which bucket** before staging anything. Walk the output of `git status` and classify each modified file:
+   - **Research bucket** (commit on `master`): `wiki/**`, `raw/**`, `README.md`, anything created or updated by the ingest itself.
+   - **Workflow bucket** (PR): `workflows/**`, `AGENTS.md` (if the workflow index changed), and any new schema/process documentation.
+   - **Do not touch**: any modified file you did *not* write to during this session. Pre-existing in-progress work in the working tree must not be staged. The session-start `git status` (captured in the system context) is the source of truth for what was already dirty before you began.
+
+2. **Stage the research files explicitly by path**, not with `git add -A` or `git add .`. Explicit paths prevent accidentally staging the user's pre-existing in-progress work, the `.codex/` or `.mcp.json` shells, or `.obsidian/graph.json` auto-saves. Verify with `git status` that the staged set matches your research bucket exactly and that the workflow files remain unstaged.
+
+3. **Commit on `master`** with a descriptive message that names the paper, summarizes the contribution, lists created/updated pages, and notes any cleanup work bundled in (e.g., paper-count sweeps, checklist resync). Follow the existing repo style (`git log --oneline -5` to compare). Always include the `Co-Authored-By` trailer.
+
+4. **Push `master`** to `origin`. The research commit is now durable.
+
+5. **If workflow files were also touched**, create a PR for them — do not commit workflow changes directly to `master`:
+   a. `git checkout -b workflow-<short-descriptor>` (e.g. `workflow-improvements-gap-analysis-discipline`). The branch starts from current `master` so the unstaged workflow changes carry over automatically.
+   b. Stage the workflow files explicitly (`workflows/*.md` and any related schema files).
+   c. Commit on the branch with a message that explains the *regression class* the workflow change prevents, not just the line-level diff. (E.g. "Add per-direction analysis review + count-drift sweep + checklist sync to ingest workflow" with a body explaining what was missed in the most recent run.)
+   d. `git push -u origin <branch>`.
+   e. `gh pr create --title "..." --body "..."` with a body that includes a Summary section (regression classes addressed) and a Test plan section (how to verify the new instructions work on the next ingest).
+   f. Return to `master` (`git checkout master`) so subsequent work does not accidentally land on the PR branch.
+
+6. **If only research files were touched**, skip step 5 — no PR needed.
+
+The rationale for splitting: research changes are continuous and trusted (the user reviews them directly via the wiki). Workflow changes are meta-level — they shape every future ingest — so they deserve a PR review surface even if the author is the same. This is the same defense-in-depth principle as the count-drift sweep: catch regressions at the boundary where they are cheapest to fix.
 
 ## Completion Checklist
 
@@ -191,11 +232,16 @@ For single-paper ingests, triggers 2-4 always fire; trigger 1 fires conditionall
 - The chosen paper was checked for appropriateness with explicit reasoning before ingest.
 - The downloader script (`raw/download_arxiv_papers.py`) was updated and run.
 - `raw/index.md` was updated with the new PDF and LaTeX entries and summary counts.
+- `raw/checklist.md` was updated with a new row for the chosen paper (URL audit trail, parallel to `raw/index.md`'s asset map).
 - `workflows/ingest.md` was followed end-to-end (source page + entities + concepts + MOCs + analyses + index + log).
+- **Stale paper-count sweep performed** (per `workflows/ingest.md` step 11). Grepped `wiki/` for the old count and updated every match outside `wiki/log.md`. Re-verified the seven common-offender files by name: `wiki/analyses/frontier-research-directions.md`, `wiki/analyses/benchmark-overlap.md`, `wiki/analyses/paper-timeline.md`, `wiki/analyses/latentcompress-collaboration-strategy.md`, `wiki/mocs/practical-systems.md`, `wiki/overview-state-of-field.md`, `README.md`. Confirmed `wiki/log.md` historical entries were left untouched.
+- Every numbered direction in `frontier-research-directions.md` and every numbered tension in `contradictions.md` was reviewed *individually* (not just the analysis page as a whole) — a single new paper often updates multiple directions/tensions and the page-level "is this relevant?" question hides individual matches.
 - All Phase 4 downstream workflow triggers were explicitly checked and acted on (or explicitly noted as not firing).
 - Lint sweep verified no broken wiki-links or anchors were introduced.
 - The run was self-graded against the rubric and any < 10/10 items were fixed.
 - A comprehensive entry was appended to `wiki/log.md` documenting the full propagation.
+- **Phase 6 executed**: research files staged by explicit path (not `git add -A`), committed on `master` with a descriptive message including the `Co-Authored-By` trailer, and pushed to `origin`. Pre-existing in-progress work in the working tree was *not* staged.
+- **If workflow files were touched**: a feature branch was created, workflow files were committed on the branch, the branch was pushed, and a PR was opened with a Summary + Test plan body. The branch name follows `workflow-<descriptor>` and the local checkout was returned to `master` after the PR was created.
 
 ## Related Workflows
 

--- a/workflows/ingest.md
+++ b/workflows/ingest.md
@@ -93,22 +93,46 @@ Do not use this workflow when the task is only to answer a question, run a lint 
 6. Update `wiki/index.md` and verify directory tree counts.
 7. Update relevant MOC pages (`wiki/mocs/*.md`) to add the new source or concept to the correct reading path.
 8. If the source is on arXiv, update `raw/download_arxiv_papers.py` so the downloader includes the new paper ID and the correct LaTeX storage mode (`archive` vs `extract`).
-9. Update `raw/index.md` to add the new PDF and LaTeX source to the asset mapping.
-10. Check living analyses and update any that are relevant:
-   - `contradictions.md` for new conflicts or nuance
-   - `open-questions.md` for new questions or answers
-   - `benchmark-overlap.md` for new benchmark results
-11. Append an entry to `wiki/log.md`.
-12. Report the outcome to the user: pages created, pages updated, and any contradictions found.
+9. Update `raw/index.md` to add the new PDF and LaTeX source to the asset mapping. **Also append a new row to `raw/checklist.md`** (the URL audit trail, parallel to `raw/index.md`'s asset map). The checklist has eight columns: `Paper | Original refs from list | Canonical PDF download | Canonical LaTeX/source download | PDF present | Local PDF | LaTeX present | Local LaTeX/source`. Fill the row as follows:
+   - **Paper**: the paper title.
+   - **Original refs from list**: `arXiv:XXXX.XXXXX` plus any venue-duplicate IDs (OpenReview, ACL, EMNLP, ICLR, NeurIPS, ICML) that appear in the "Duplicate PDFs (Venue Copies)" section of `raw/index.md` for this paper. Separate multiple refs with `;`.
+   - **Canonical PDF download**: `https://arxiv.org/pdf/{id}` (use the bare ID, no version suffix unless intentionally pinning).
+   - **Canonical LaTeX/source download**: `https://arxiv.org/e-print/{id}`.
+   - **PDF present** / **LaTeX present**: `Yes` once the downloader has run.
+   - **Local PDF**: `raw/pdf/arxiv-XXXX.XXXXX.pdf`. **Do not use `reference/pdf/...`** — that is a stale historical path from a pre-move vault layout and has caused drift in the past.
+   - **Local LaTeX/source**: must match the actual on-disk format chosen in `raw/download_arxiv_papers.py`. Use `raw/latex/arxiv-XXXX.XXXXX/` (trailing slash) for `extract`-mode papers whose source was unpacked into a directory, and `raw/latex/arxiv-XXXX.XXXXX.tar.gz` for `archive`-mode papers stored as a tarball.
+
+   The invariant: every arXiv paper listed in `raw/index.md`'s "Canonical PDFs" table must have exactly one corresponding row in `raw/checklist.md`. Non-arXiv sources (e.g., the latentcompress GitHub project) are intentionally excluded from the checklist.
+10. Check **every** living analysis page in `wiki/analyses/` and update any that the new source touches. The full set is enumerated below — do not skip any. Every direction in `frontier-research-directions.md` and every tension in `contradictions.md` must be reviewed individually, not just the analysis page as a whole, because a single new paper often updates multiple directions or tensions and the high-level "is this page relevant?" question hides individual matches.
+   - `contradictions.md` — for each numbered tension, ask whether the new source adds a new claim, resolves an existing one, or shifts the status. Update the per-tension sub-claims table and the summary table at the end.
+   - `frontier-research-directions.md` — for each numbered direction (1-8), ask whether the new source provides additional empirical support, a new blocker, or a new "concrete next step" that is now closed. **A new paper often blocks or advances multiple directions** — review every direction individually before moving on.
+   - `open-questions.md` — for each clustered question, ask whether the new source partially or fully answers it, or raises a new question that fits an existing cluster.
+   - `benchmark-overlap.md` — add new rows to the master matrix and the per-benchmark focused tables; update paper count, methodology paragraph, and any "<XB cluster" or blind-spot notes affected.
+   - `paper-timeline.md` — add the paper to the correct year/month entry in chronological order; update the year-narrative paragraph if the new paper changes the field's trajectory.
+   - `method-comparison.md` — add a row to the appropriate method category table (Reasoning / Communication / Unified / Diagnostic), or note in the cross-cutting analysis if the paper alters a trade-off.
+   - Any other `wiki/analyses/*.md` page that exists at ingest time (the analysis directory grows over time — re-list it before assuming this enumeration is complete).
+11. **Stale paper-count sweep** (mandatory, do not skip — this is a first-class regression class that has bitten previous ingests). Hardcoded paper counts in body prose drift every time a paper is added, because the "update index/README counts" instruction only catches the badge counts and the directory tree, *not* the prose counts buried in MOC blurbs and analysis intros.
+    a. **Determine the old and new counts**: before this ingest, there were $N$ source pages; after this ingest, there are $N+1$ (or $N+k$ for batch). Note both numbers explicitly.
+    b. **Grep the wiki for the old count**: run Grep for `\b{old_count}\s+(papers|source pages|source papers)\b` over `wiki/`. This catches the most common phrasings. Also grep for `(synthesized|covers|across|all)\s+\b{old_count}\b` to catch variants like "synthesized from all 25 papers" or "wiki covers 25 papers".
+    c. **Update every match outside `wiki/log.md`**. Log entries are point-in-time records and must never be backdated — leave them alone.
+    d. **Common offenders to check by name** (re-verify each one even if grep returns clean): `wiki/analyses/frontier-research-directions.md` (intro line ~11), `wiki/analyses/benchmark-overlap.md` (page intro + methodology paragraph + "Multilingual benchmarks" blind-spot bullet + "Source Materials" footer), `wiki/analyses/paper-timeline.md` (page intro), `wiki/analyses/latentcompress-collaboration-strategy.md` ("What We Have That They Don't" + collaboration pitch), `wiki/mocs/practical-systems.md` (paper-timeline blurb), `wiki/overview-state-of-field.md` (opening paragraph), `README.md` (badge + paragraph + per-thread `(N papers)` summary blocks), `wiki/index.md` (directory tree counts).
+    e. **Also sweep for other count drifts**: entity count, MOC count, analysis count, concept count (these appear in `wiki/index.md`'s directory tree, in the README badges, and occasionally in MOC text). Use the same grep-then-update pattern.
+12. Append an entry to `wiki/log.md`.
+13. Report the outcome to the user: pages created, pages updated, and any contradictions found.
+14. **Commit and push** (mirrors `workflows/gap-analysis.md` Phase 6 — apply the same discipline when ingest is invoked directly). Stage research files by explicit path (not `git add -A`); never stage pre-existing in-progress work, `.codex/`, `.mcp.json`, or `.obsidian/graph.json`. Commit on `master` with a descriptive message and the `Co-Authored-By` trailer. Push `master`. **If workflow files were also touched**, create a feature branch, commit workflow changes on the branch, push, and open a PR with a Summary + Test plan body — never commit workflow changes directly to `master`. See `workflows/gap-analysis.md` Phase 6 for the full procedure.
 
 ## Completion Checklist
 
 - The source page exists in the correct `wiki/sources/` location.
 - All relevant entity and concept pages were updated or created.
-- `wiki/index.md` reflects the new pages.
+- `wiki/index.md` reflects the new pages **and** all directory-tree counts (sources, entities, MOCs, analyses, concepts) are updated.
 - Relevant MOCs include the new reading path entries.
 - `raw/index.md` and `raw/download_arxiv_papers.py` were updated if needed.
-- Relevant analysis pages were checked or updated.
+- `raw/checklist.md` includes a new row for the ingested paper, with `raw/pdf/...` (not `reference/...`) paths and any venue-duplicate refs.
+- Every numbered direction in `frontier-research-directions.md` and every numbered tension in `contradictions.md` was reviewed individually (not just the page as a whole).
+- All 6+ living analyses in `wiki/analyses/` were checked.
+- **Stale paper-count sweep performed**: grepped for the old count and updated every match outside `wiki/log.md`. The seven common-offender files (frontier-research-directions, benchmark-overlap × 4 places, paper-timeline, latentcompress-collaboration-strategy × 2 places, practical-systems MOC, overview-state-of-field, README, wiki/index) were re-verified by name even if grep returned clean.
+- `README.md` badge counts, paragraph text, and per-thread `(N papers)` summary headers all reflect the new count.
 - `wiki/log.md` includes the ingest entry.
 
 ## Related Workflows

--- a/workflows/lint.md
+++ b/workflows/lint.md
@@ -92,13 +92,26 @@ Use this workflow when you need to audit the wiki for quality issues, especially
    - MOC files live at `wiki/mocs/*.md`.
    - Concepts live in `wiki/concepts/`.
    - Full-path wiki-links in `raw/index.md` match actual file locations.
-   - `wiki/index.md` directory tree counts match actual page counts.
-- `AGENTS.md` Current MOCs list matches the actual `wiki/mocs/*.md` files.
-- No stale path references remain in `AGENTS.md`, `README.md`, or index files after reorganizations.
+   - `wiki/index.md` directory tree counts match actual page counts (sources, entities, MOCs, analyses, concepts).
+   - `AGENTS.md` Current MOCs list matches the actual `wiki/mocs/*.md` files.
+   - No stale path references remain in `AGENTS.md`, `README.md`, or index files after reorganizations.
    - Mermaid node labels use `<br>` for line breaks, not `\n` (which renders literally in Obsidian).
-3. Report findings and suggest fixes.
-4. Apply fixes only after user approval.
-5. Log the lint pass in `wiki/log.md`.
+3. **Paper-count drift sweep** (catches the regression class where prose counts drift after ingests):
+   - Determine the *authoritative* current count by `ls wiki/sources/**/*.md | wc -l` (or equivalent Glob).
+   - Grep `wiki/` and `README.md` for any number followed by `papers`, `source pages`, or `source papers` (e.g., `\b\d+\s+(papers|source pages|source papers)\b`).
+   - Also grep for the patterns `synthesized from all \d+`, `wiki covers \d+`, and `(across|all) \d+ papers` to catch variant phrasings.
+   - Flag every match where the number does not equal the authoritative count, **except** matches in `wiki/log.md` (log entries are point-in-time records and must not be backdated).
+   - Common offenders to check by name: `wiki/analyses/frontier-research-directions.md`, `wiki/analyses/benchmark-overlap.md` (4 places), `wiki/analyses/paper-timeline.md`, `wiki/analyses/latentcompress-collaboration-strategy.md` (2 places), `wiki/mocs/practical-systems.md`, `wiki/overview-state-of-field.md`, `README.md` (badges + paragraph + per-thread `(N papers)` headers), `wiki/index.md` (directory tree).
+   - Also sweep entity counts, MOC counts, analysis counts, and concept counts using the same pattern (`\b\d+\s+(entit|MOC|analyses|concepts)`).
+4. **Checklist sync check** (catches drift between `raw/index.md` and `raw/checklist.md`, the URL audit trail). The checklist tracks arXiv papers only; non-arXiv sources (e.g., the latentcompress GitHub project) are intentionally excluded, so the row count must be compared against the *Canonical PDFs* count in `raw/index.md`'s summary table, **not** the total unique source pages count.
+   - Count the canonical PDF rows in `raw/index.md` (the "Canonical PDFs" table, excluding the venue-duplicate section and any non-arXiv rows).
+   - Count the data rows in `raw/checklist.md` (the markdown table, excluding the header and separator rows).
+   - Confirm the two counts match. If they do not, flag the delta.
+   - Grep `raw/checklist.md` for `reference/pdf/` and `reference/latex/`. Zero matches are required — these are stale historical paths from a directory move and must be rewritten to `raw/pdf/...` / `raw/latex/...`.
+   - For each canonical PDF arxiv ID in `raw/index.md`, confirm a matching row exists in `raw/checklist.md` (match by arxiv ID in either the "Original refs from list" column or the "Local PDF" path). Flag any arxiv IDs present in `raw/index.md` but missing from `raw/checklist.md`, and any rows in `raw/checklist.md` whose arxiv ID is not in `raw/index.md`.
+5. Report findings and suggest fixes.
+6. Apply fixes only after user approval.
+7. Log the lint pass in `wiki/log.md`.
 
 ## Completion Checklist
 - Findings are grouped by content vs structural issues.


### PR DESCRIPTION
## Summary

Patches the ingest, gap-analysis, and lint workflows to catch four regression classes that bit recent ingests of Cui et al. (2026) and Wang et al. (2025).

- **Per-direction analysis review** — `frontier-research-directions.md` direction #2 was missed in the Wang et al. ingest because the previous instruction (`check living analyses and update any that are relevant`) was page-level, not item-level. New `ingest.md` step 10 enumerates all 6+ living analyses and requires per-numbered-item review of `frontier-research-directions` and `contradictions`.
- **Stale paper-count sweep** — hardcoded `25 papers` strings in MOC blurbs, analysis intros, blind-spot bullets, and per-thread README headers drifted across two ingests. New `ingest.md` step 11 is a first-class sweep with grep recipe, named-offender list, and an explicit `wiki/log.md` exclusion (log entries are point-in-time records). Mirrored as a `Count-drift discipline` rubric item in `gap-analysis.md` Phase 5 (scores 0/10 if any prose count is stale) and as `lint.md` step 3.
- **`raw/checklist.md` sync** — the URL audit trail had no maintenance contract in any workflow. It accreted stale `reference/pdf/...` paths from a months-old directory move and was missing 10 papers from prior ingests. New `ingest.md` step 9 extends the asset-map update to also append a checklist row with full column spec, URL templates, `raw/pdf/` (not `reference/pdf/`) requirement, and LaTeX storage-mode matching. New `lint.md` step 4 verifies row-count parity vs `raw/index.md`, zero stale `reference/` matches, and bidirectional per-arxiv-ID presence.
- **Commit/PR discipline** — uncommitted ingest work was fragile and workflow changes had no review surface. New `gap-analysis.md` Phase 6 codifies the pattern: research files commit straight to `master` (explicit-path staging, descriptive message, `Co-Authored-By` trailer); workflow files go through a PR on a feature branch with a Summary + Test plan body. Mirrored as `ingest.md` step 14.

**Defense in depth**: ingest prevents drift, gap-analysis self-grade rubric scores 0/10 if drift is introduced, lint catches drift that escapes both. Same pattern applied to both the count-drift and checklist-sync invariants.

## Test plan

- [ ] Next gap-analysis run touches a paper that affects multiple `frontier-research-directions.md` directions, and the run reviews each numbered direction individually rather than skipping after the first match.
- [ ] Next ingest's `git diff --stat` for `wiki/analyses/` shows updates to every relevant analysis page, not just `contradictions` / `open-questions` / `benchmark-overlap`.
- [ ] Next ingest grep for the *previous* paper count (e.g., `\b27\s+(papers|source pages|source papers)\b` if going from 27 → 28) returns zero matches outside `wiki/log.md`.
- [ ] Next ingest appends a row to `raw/checklist.md` with `raw/pdf/...` (not `reference/pdf/...`) paths.
- [ ] A standalone `lint.md` run reports row-count parity between `raw/index.md` Canonical PDFs and `raw/checklist.md` data rows.
- [ ] Next gap-analysis run executes Phase 6: research files committed on `master` via explicit-path staging, then either confirms no workflow files were touched OR creates a feature-branch PR with Summary + Test plan body.
- [ ] After the PR is created, the local checkout returns to `master` so subsequent work does not accidentally land on the PR branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)