### PR TITLE
Workflow refinements: slug disambiguation, venue_pdfs verification, redundancy audit

### DIFF
--- a/workflows/ingest.md
+++ b/workflows/ingest.md
@@ -81,45 +81,46 @@ Do not use this workflow when the task is only to answer a question, run a lint 
 
 1. Read the source file in `raw/`.
 2. Discuss key takeaways with the user. Ask what to emphasize if unclear.
-3. Create a source summary page in the appropriate `wiki/sources/` subdirectory. Include:
+3. **Pick a slug that disambiguates by default.** Before creating the file, `Glob wiki/sources/**/*.md` and check whether the leading hyphen-token of your candidate slug already exists (e.g., another `kvcomm-*` or `coconut-*`). If it does, use the hybrid form `<technique>-<institution>-<distinguisher>.md` so collisions never accumulate.
+4. Create a source summary page in the appropriate `wiki/sources/` subdirectory. Include:
    - Full frontmatter: `type`, `title`, `source_file`, `latex_source` (if available), `author`, `date_published`, `date_ingested`, `created`, `tags`.
-   - If venue duplicate PDFs exist, add `venue_pdfs:`.
-   - A `## Source Materials` footer linking to the PDF and LaTeX source.
+   - If venue duplicate PDFs exist **and the file is actually present in `raw/pdf/`**, add `venue_pdfs:`. **Never list a venue PDF you have not downloaded** — verify each path with `Glob` before writing the frontmatter. Phantom `venue_pdfs:` entries propagate into `raw/index.md` and break lint passes weeks later.
+   - A `## Source Materials` footer linking to the PDF and LaTeX source. Both paths must already exist on disk.
    - Section-specific detail per the depth standard.
-4. For each significant entity or concept mentioned:
+5. For each significant entity or concept mentioned:
    - If a page exists, update it with new information and cite the new source.
    - If no page exists, create one with `title:` in frontmatter.
-5. For each institution involved, update or create the entity page with a contribution timeline entry.
-6. Update `wiki/index.md` and verify directory tree counts.
-7. Update relevant MOC pages (`wiki/mocs/*.md`) to add the new source or concept to the correct reading path.
-8. If the source is on arXiv, update `raw/download_arxiv_papers.py` so the downloader includes the new paper ID and the correct LaTeX storage mode (`archive` vs `extract`).
-9. Update `raw/index.md` to add the new PDF and LaTeX source to the asset mapping. **Also append a new row to `raw/checklist.md`** (the URL audit trail, parallel to `raw/index.md`'s asset map). The checklist has eight columns: `Paper | Original refs from list | Canonical PDF download | Canonical LaTeX/source download | PDF present | Local PDF | LaTeX present | Local LaTeX/source`. Fill the row as follows:
-   - **Paper**: the paper title.
-   - **Original refs from list**: `arXiv:XXXX.XXXXX` plus any venue-duplicate IDs (OpenReview, ACL, EMNLP, ICLR, NeurIPS, ICML) that appear in the "Duplicate PDFs (Venue Copies)" section of `raw/index.md` for this paper. Separate multiple refs with `;`.
-   - **Canonical PDF download**: `https://arxiv.org/pdf/{id}` (use the bare ID, no version suffix unless intentionally pinning).
-   - **Canonical LaTeX/source download**: `https://arxiv.org/e-print/{id}`.
-   - **PDF present** / **LaTeX present**: `Yes` once the downloader has run.
-   - **Local PDF**: `raw/pdf/arxiv-XXXX.XXXXX.pdf`. **Do not use `reference/pdf/...`** — that is a stale historical path from a pre-move vault layout and has caused drift in the past.
-   - **Local LaTeX/source**: must match the actual on-disk format chosen in `raw/download_arxiv_papers.py`. Use `raw/latex/arxiv-XXXX.XXXXX/` (trailing slash) for `extract`-mode papers whose source was unpacked into a directory, and `raw/latex/arxiv-XXXX.XXXXX.tar.gz` for `archive`-mode papers stored as a tarball.
+6. For each institution involved, update or create the entity page with a contribution timeline entry.
+7. Update `wiki/index.md` and verify directory tree counts.
+8. Update relevant MOC pages (`wiki/mocs/*.md`) to add the new source or concept to the correct reading path.
+9. If the source is on arXiv, update `raw/download_arxiv_papers.py` so the downloader includes the new paper ID and the correct LaTeX storage mode (`archive` vs `extract`).
+10. Update `raw/index.md` to add the new PDF and LaTeX source to the asset mapping. **Also append a new row to `raw/checklist.md`** (the URL audit trail, parallel to `raw/index.md`'s asset map). The checklist has eight columns: `Paper | Original refs from list | Canonical PDF download | Canonical LaTeX/source download | PDF present | Local PDF | LaTeX present | Local LaTeX/source`. Fill the row as follows:
+    - **Paper**: the paper title.
+    - **Original refs from list**: `arXiv:XXXX.XXXXX` plus any venue-duplicate IDs (OpenReview, ACL, EMNLP, ICLR, NeurIPS, ICML) that appear in the "Duplicate PDFs (Venue Copies)" section of `raw/index.md` for this paper. Separate multiple refs with `;`. **Only include venue refs whose PDF is actually present in `raw/pdf/`** — same constraint as step 4's `venue_pdfs:` frontmatter.
+    - **Canonical PDF download**: `https://arxiv.org/pdf/{id}` (use the bare ID, no version suffix unless intentionally pinning).
+    - **Canonical LaTeX/source download**: `https://arxiv.org/e-print/{id}`.
+    - **PDF present** / **LaTeX present**: `Yes` once the downloader has run.
+    - **Local PDF**: `raw/pdf/arxiv-XXXX.XXXXX.pdf`. **Do not use `reference/pdf/...`** — that is a stale historical path from a pre-move vault layout and has caused drift in the past.
+    - **Local LaTeX/source**: must match the actual on-disk format chosen in `raw/download_arxiv_papers.py`. Use `raw/latex/arxiv-XXXX.XXXXX/` (trailing slash) for `extract`-mode papers whose source was unpacked into a directory, and `raw/latex/arxiv-XXXX.XXXXX.tar.gz` for `archive`-mode papers stored as a tarball.
 
-   The invariant: every arXiv paper listed in `raw/index.md`'s "Canonical PDFs" table must have exactly one corresponding row in `raw/checklist.md`. Non-arXiv sources (e.g., the latentcompress GitHub project) are intentionally excluded from the checklist.
-10. Check **every** living analysis page in `wiki/analyses/` and update any that the new source touches. The full set is enumerated below — do not skip any. Every direction in `frontier-research-directions.md` and every tension in `contradictions.md` must be reviewed individually, not just the analysis page as a whole, because a single new paper often updates multiple directions or tensions and the high-level "is this page relevant?" question hides individual matches.
-   - `contradictions.md` — for each numbered tension, ask whether the new source adds a new claim, resolves an existing one, or shifts the status. Update the per-tension sub-claims table and the summary table at the end.
-   - `frontier-research-directions.md` — for each numbered direction (1-8), ask whether the new source provides additional empirical support, a new blocker, or a new "concrete next step" that is now closed. **A new paper often blocks or advances multiple directions** — review every direction individually before moving on.
-   - `open-questions.md` — for each clustered question, ask whether the new source partially or fully answers it, or raises a new question that fits an existing cluster.
-   - `benchmark-overlap.md` — add new rows to the master matrix and the per-benchmark focused tables; update paper count, methodology paragraph, and any "<XB cluster" or blind-spot notes affected.
-   - `paper-timeline.md` — add the paper to the correct year/month entry in chronological order; update the year-narrative paragraph if the new paper changes the field's trajectory.
-   - `method-comparison.md` — add a row to the appropriate method category table (Reasoning / Communication / Unified / Diagnostic), or note in the cross-cutting analysis if the paper alters a trade-off.
-   - Any other `wiki/analyses/*.md` page that exists at ingest time (the analysis directory grows over time — re-list it before assuming this enumeration is complete).
-11. **Stale paper-count sweep** (mandatory, do not skip — this is a first-class regression class that has bitten previous ingests). Hardcoded paper counts in body prose drift every time a paper is added, because the "update index/README counts" instruction only catches the badge counts and the directory tree, *not* the prose counts buried in MOC blurbs and analysis intros.
+    The invariant: every arXiv paper listed in `raw/index.md`'s "Canonical PDFs" table must have exactly one corresponding row in `raw/checklist.md`. Non-arXiv sources (e.g., the latentcompress GitHub project) are intentionally excluded from the checklist.
+11. Check **every** living analysis page in `wiki/analyses/` and update any that the new source touches. The full set is enumerated below — do not skip any. Every direction in `frontier-research-directions.md` and every tension in `contradictions.md` must be reviewed individually, not just the analysis page as a whole, because a single new paper often updates multiple directions or tensions and the high-level "is this page relevant?" question hides individual matches.
+    - `contradictions.md` — for each numbered tension, ask whether the new source adds a new claim, resolves an existing one, or shifts the status. Update the per-tension sub-claims table and the summary table at the end.
+    - `frontier-research-directions.md` — for each numbered direction (1-8), ask whether the new source provides additional empirical support, a new blocker, or a new "concrete next step" that is now closed. **A new paper often blocks or advances multiple directions** — review every direction individually before moving on.
+    - `open-questions.md` — for each clustered question, ask whether the new source partially or fully answers it, or raises a new question that fits an existing cluster.
+    - `benchmark-overlap.md` — add new rows to the master matrix and the per-benchmark focused tables; update paper count, methodology paragraph, and any "<XB cluster" or blind-spot notes affected.
+    - `paper-timeline.md` — add the paper to the correct year/month entry in chronological order; update the year-narrative paragraph if the new paper changes the field's trajectory.
+    - `method-comparison.md` — add a row to the appropriate method category table (Reasoning / Communication / Unified / Diagnostic), or note in the cross-cutting analysis if the paper alters a trade-off.
+    - Any other `wiki/analyses/*.md` page that exists at ingest time (the analysis directory grows over time — re-list it before assuming this enumeration is complete).
+12. **Stale paper-count sweep** (mandatory, do not skip — this is a first-class regression class that has bitten previous ingests). Hardcoded paper counts in body prose drift every time a paper is added, because the "update index/README counts" instruction only catches the badge counts and the directory tree, *not* the prose counts buried in MOC blurbs and analysis intros.
     a. **Determine the old and new counts**: before this ingest, there were $N$ source pages; after this ingest, there are $N+1$ (or $N+k$ for batch). Note both numbers explicitly.
     b. **Grep the wiki for the old count**: run Grep for `\b{old_count}\s+(papers|source pages|source papers)\b` over `wiki/`. This catches the most common phrasings. Also grep for `(synthesized|covers|across|all)\s+\b{old_count}\b` to catch variants like "synthesized from all 25 papers" or "wiki covers 25 papers".
     c. **Update every match outside `wiki/log.md`**. Log entries are point-in-time records and must never be backdated — leave them alone.
     d. **Common offenders to check by name** (re-verify each one even if grep returns clean): `wiki/analyses/frontier-research-directions.md` (intro line ~11), `wiki/analyses/benchmark-overlap.md` (page intro + methodology paragraph + "Multilingual benchmarks" blind-spot bullet + "Source Materials" footer), `wiki/analyses/paper-timeline.md` (page intro), `wiki/analyses/latentcompress-collaboration-strategy.md` ("What We Have That They Don't" + collaboration pitch), `wiki/mocs/practical-systems.md` (paper-timeline blurb), `wiki/overview-state-of-field.md` (opening paragraph), `README.md` (badge + paragraph + per-thread `(N papers)` summary blocks), `wiki/index.md` (directory tree counts).
     e. **Also sweep for other count drifts**: entity count, MOC count, analysis count, concept count (these appear in `wiki/index.md`'s directory tree, in the README badges, and occasionally in MOC text). Use the same grep-then-update pattern.
-12. Append an entry to `wiki/log.md`.
-13. Report the outcome to the user: pages created, pages updated, and any contradictions found.
-14. **Commit and push** (mirrors `workflows/gap-analysis.md` Phase 6 — apply the same discipline when ingest is invoked directly). Stage research files by explicit path (not `git add -A`); never stage pre-existing in-progress work, `.codex/`, `.mcp.json`, or `.obsidian/graph.json`. Commit on `master` with a descriptive message and the `Co-Authored-By` trailer. Push `master`. **If workflow files were also touched**, create a feature branch, commit workflow changes on the branch, push, and open a PR with a Summary + Test plan body — never commit workflow changes directly to `master`. See `workflows/gap-analysis.md` Phase 6 for the full procedure.
+13. Append an entry to `wiki/log.md`.
+14. Report the outcome to the user: pages created, pages updated, and any contradictions found.
+15. **Commit and push** (mirrors `workflows/gap-analysis.md` Phase 6 — apply the same discipline when ingest is invoked directly). Stage research files by explicit path (not `git add -A`); never stage pre-existing in-progress work, `.codex/`, `.mcp.json`, or `.obsidian/graph.json`. Commit on `master` with a descriptive message and the `Co-Authored-By` trailer. Push `master`. **If workflow files were also touched**, create a feature branch, commit workflow changes on the branch, push, and open a PR with a Summary + Test plan body — never commit workflow changes directly to `master`. See `workflows/gap-analysis.md` Phase 6 for the full procedure.
 
 ## Completion Checklist
 

--- a/workflows/lint.md
+++ b/workflows/lint.md
@@ -109,9 +109,64 @@ Use this workflow when you need to audit the wiki for quality issues, especially
    - Confirm the two counts match. If they do not, flag the delta.
    - Grep `raw/checklist.md` for `reference/pdf/` and `reference/latex/`. Zero matches are required — these are stale historical paths from a directory move and must be rewritten to `raw/pdf/...` / `raw/latex/...`.
    - For each canonical PDF arxiv ID in `raw/index.md`, confirm a matching row exists in `raw/checklist.md` (match by arxiv ID in either the "Original refs from list" column or the "Local PDF" path). Flag any arxiv IDs present in `raw/index.md` but missing from `raw/checklist.md`, and any rows in `raw/checklist.md` whose arxiv ID is not in `raw/index.md`.
-5. Report findings and suggest fixes.
-6. Apply fixes only after user approval.
-7. Log the lint pass in `wiki/log.md`.
+5. Run the **Redundancy & Dead-Reference Audit** (see section below). This is a four-class sub-pass that catches phantom raw assets, source-page ↔ raw asset bijection breaks, slug collisions, and MOC/concept overlap.
+6. Report findings and suggest fixes.
+7. Apply fixes only after user approval.
+8. Log the lint pass in `wiki/log.md`.
+
+## Redundancy & Dead-Reference Audit
+
+A focused sub-pass that catches the four classes of bug found in the 2026-04-08 audit. Run all four checks; report each class separately.
+
+### A. Phantom raw asset references
+
+Every `source_file:`, `latex_source:`, and `venue_pdfs:` value, plus every `[[raw/...|...]]` body link, must point to an actual file on disk.
+
+1. `Glob raw/pdf/*` and `Glob raw/latex/*` to enumerate what exists.
+2. `Grep -n 'source_file:|latex_source:|venue_pdfs:' wiki/sources/` to enumerate frontmatter claims.
+3. `Grep -n '\[\[raw/' wiki` to enumerate body-link claims.
+4. Diff: any path referenced but not present is a phantom. Fix by either (a) re-acquiring the file, or (b) deleting the reference and updating `raw/index.md` and the summary table.
+
+### B. Source-page ↔ raw asset bijection
+
+The wiki's invariant: every `arxiv:` ID in `wiki/sources/**/*.md` maps 1:1 to a PDF in `raw/pdf/`, and vice versa. Exceptions: pages with no `arxiv:` field (external projects, GitHub-only sources).
+
+1. `Grep -n '^arxiv:' wiki/sources` → list of ingested arXiv IDs.
+2. `Glob raw/pdf/arxiv-*.pdf` → list of stored PDFs.
+3. Diff. An ID in (1) but not (2) means a missing download. A PDF in (2) but not (1) means an unreferenced raw asset (potentially redundant).
+4. Cross-check the same against `raw/index.md`'s "Canonical PDFs" table — any row that no longer matches a source page is stale.
+
+### C. Slug collisions and naming ambiguity
+
+When two source pages share a leading filename token (e.g., `kvcomm-*`, `coconut-*`), readers can't disambiguate without opening both. Flag any cluster of 2+ files in the same `wiki/sources/**/` directory whose slugs share the first token.
+
+1. `Glob wiki/sources/**/*.md` and group basenames by their first hyphenated token.
+2. For any group with size ≥ 2 from different papers, suggest a hybrid rename: `<technique>-<institution>-<distinguisher>.md` (e.g., `kvcomm-kth-selective.md` vs `kvcomm-duke-online-reuse.md`).
+3. Renames are bulk operations — see "Bulk source-page rename" below.
+
+### D. MOC and concept overlap
+
+Two MOCs are redundant when one defers to the other for its primary content. Two concept pages are redundant when their bullet lists overlap by more than ~50%.
+
+1. `Grep -n 'see \*\*\[\[|see the full' wiki/mocs/` — explicit deferrals are a smell.
+2. For any MOC whose body section is duplicated in another MOC, propose collapsing it to the unique scaffolding (cross-cutting concepts, key entities, theoretical foundations) and adding a one-line pointer to the canonical source.
+3. For concept-page overlap, prefer keeping the synthesis page and folding the duplicate into a section anchor.
+
+## Bulk source-page rename
+
+When option **C** above triggers (or any other rename of a source page slug), follow this exact sequence to keep all backlinks consistent. **Do not** edit one file at a time — the surface area is large enough that a single missed link breaks navigation.
+
+1. **Enumerate references first**: `Grep '\[\[<old-slug>' .` — confirm the count and the files affected.
+2. **Move the file with `git mv`** so history is preserved. Never use `Write` to create a new file alongside the old.
+3. **Bulk rewrite all references**. The blessed tool for this single case is `sed` (the only place where `sed` overrides the "use Edit, not sed" default), because (a) the slug is unique enough that collateral damage is impossible to introduce, and (b) the alternative is 30+ Read+Edit pairs:
+
+   ```bash
+   find wiki raw -name "*.md" -print0 | xargs -0 sed -i 's/<old-slug>/<new-slug>/g'
+   ```
+
+4. **Verify**: re-run `Grep '<old-slug>' .` — must return zero matches.
+5. **Update `raw/index.md`** if the source page is also referenced there (the sed pass usually handles this — confirm).
+6. **Log it** in `wiki/log.md` with action `lint` or `update`, listing both the old and new slugs.
 
 ## Completion Checklist
 - Findings are grouped by content vs structural issues.


### PR DESCRIPTION
## Summary

Merge resolution that combines two parallel streams of workflow improvements that landed on master via PR #1 and the user's local working-tree refinements that were stashed during the PR #2 rename refactor. Both streams modify `workflows/ingest.md` and `workflows/lint.md` and conflict on the procedure step list. This PR ships the union.

### `workflows/ingest.md`

- **Step 3 (NEW)**: *Pick a slug that disambiguates by default*. Glob the existing source files and check whether the leading hyphen-token of the candidate slug already exists. If it does, use the hybrid form `<technique>-<institution>-<distinguisher>.md`. This codifies the lesson learned from PR #2 (the kvcomm rename refactor) so collisions never accumulate again.
- **Step 4 (REFINED)**: `venue_pdfs:` frontmatter must only list venue PDFs that are actually present in `raw/pdf/`. Phantom `venue_pdfs:` entries propagate into `raw/index.md` and break lint passes weeks later. The `Source Materials` footer must reference paths that exist on disk.
- **Steps 5-15**: PR #1's expanded procedure (raw/checklist.md sync at step 10, per-direction analysis review at step 11, stale paper-count sweep at step 12, commit/push/PR phase at step 15), renumbered to accommodate the new step 3.
- **Step 10 refinement**: the checklist row instructions also got the venue-PDF constraint — "Only include venue refs whose PDF is actually present in `raw/pdf/`".

### `workflows/lint.md`

- **Steps 1-4**: existing structural + content integrity + paper-count sweep + checklist sync (from PR #1).
- **Step 5 (NEW)**: *Run the Redundancy & Dead-Reference Audit*, a four-class sub-pass that catches:
  - **A**. Phantom raw asset references (frontmatter or body links pointing to files that don't exist).
  - **B**. Source-page ↔ raw asset bijection breaks (every `arxiv:` ID in `wiki/sources/` must map 1:1 to a PDF in `raw/pdf/`).
  - **C**. Slug collisions and naming ambiguity (the kvcomm-* class of bug caught in this session — now flagged proactively).
  - **D**. MOC and concept overlap (collapse redundant content to canonical sources).
- **New `## Bulk source-page rename` appendix**: the exact sequence to follow when option C triggers, including `git mv` (preserves history) and the blessed `sed` pattern for bulk reference rewrite. Documents the only place where `sed` overrides the harness's "use Edit, not sed" default.

## Why a separate PR

This merge resolution is itself a workflow change, so it lands via PR per `gap-analysis.md` Phase 6 — never directly to master. This PR closes the loop on the parallel workflow streams and brings master into a coherent post-merge state.

## Test plan

- [ ] After merge, both files lint clean (no conflict markers, consistent numbering).
- [ ] Next ingest exercises the new step 3 (Glob check for slug collisions before file creation).
- [ ] Next ingest's `venue_pdfs:` frontmatter is verified against `raw/pdf/` before being written.
- [ ] Next lint pass exercises the four-class Redundancy & Dead-Reference Audit and reports each class separately.
- [ ] Any future bulk rename follows the `## Bulk source-page rename` procedure and uses `git mv` + `sed` instead of one-file-at-a-time edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)