### PR TITLE
lint: prune phantom venue PDFs and collapse latent-communication MOC

### DIFF
--- a/wiki/log.md
+++ b/wiki/log.md
@@ -8,6 +8,18 @@ created: "2026-04-06"
 
 Chronological record of all wiki activity.
 
+## [2026-04-08] lint | Redundancy cleanup — phantom venue PDFs and latent-communication MOC collapse
+
+Two-part cleanup completing the redundancy audit started earlier today. The KVComm rename from the same audit landed separately as commit `b97a8a3` (PR #2); the workflow refinements that codify the audit landed as commit `e4b1f68` (PR #3). This entry covers the remaining wiki/source edits.
+
+**Phantom venue PDFs pruned (9 source pages).** Stripped `venue_pdfs:` frontmatter from the 9 source pages still carrying broken OpenReview/ACL references after the kvcomm-rename PR landed: `coconut-reasoning-latent-space`, `softcot-efficient-reasoning`, `cipher-multiagent-debate-embeddings`, `state-delta-trajectory`, `activation-communication-harvard`, `interlat-latent-space-agents`, `cache-to-cache-semantic-communication`, `thought-communication-multiagent`, `vision-wormhole-heterogeneous`. (The two `kvcomm-*` source pages and `raw/index.md` were already pruned via PR #2.) No body footers affected.
+
+**MOC overlap collapsed.** [[latent-communication]] and [[communication-depth-spectrum]] both organized the same papers along the same depth axis; the former even deferred to the latter for "the full 10-level walkthrough." Reduced `latent-communication.md` from 71 → 45 lines: removed the entire "Depth Spectrum" paper-by-paper section (replaced with a one-line pointer), kept the unique cross-cutting concepts, key entities, theoretical foundations, and connections sections. The two MOCs are now genuinely orthogonal — `latent-communication` is the thematic hub, `communication-depth-spectrum` is the paper walkthrough.
+
+**Side-effect: in-prose backlink fix in 2 source pages.** PR #2's kvcomm rename merge left two source pages with stale `[[kvcomm-selective-kv-sharing|...]]` and `[[kvcomm-online-cross-context|...]]` references in body prose: `activation-communication-harvard.md` and `cache-to-cache-semantic-communication.md`. This commit completes PR #2 by rewriting those references to the new slugs. (`wiki/log.md` historical entries containing the old slugs are intentionally left unchanged — point-in-time records.)
+
+Pages updated (11): `wiki/mocs/latent-communication.md`, `wiki/log.md`, plus 9 source pages (`venue_pdfs:` prune) of which 2 also receive in-prose backlink fixes.
+
 ## [2026-04-08] gap-analysis + ingest | Wang et al. (2025) — Towards Inference-time Scaling for Continuous Space Reasoning
 
 Performed the gap-analysis workflow end-to-end, second iteration of the day. **Phase 1**: re-audited [[frontier-research-directions]], [[contradictions]], [[open-questions]], and [[benchmark-overlap]] for the highest-priority unresolved gap after the morning's Cui et al. ingest. Top gap: the **Pass@100 / Maj@100 amplification gap** that Cui et al. identified — latent reasoning preserves correct candidates (Pass@100 +20pp) but fails to amplify them at decode (Maj@100 −3pp vs explicit). Marked as **High** priority in `contradictions.md` #9, redirecting the entire frontier-scale agenda. The gap statement: *the wiki tracks that iterative latent reasoning encodes a richer candidate distribution than explicit CoT yet collapses at majority voting, but lacks any paper that proposes or empirically tests a decoding/aggregation/training method to recover this latent diversity advantage.*

--- a/wiki/mocs/latent-communication.md
+++ b/wiki/mocs/latent-communication.md
@@ -2,7 +2,7 @@
 type: overview
 title: "Latent Communication"
 created: "2026-04-06"
-updated: "2026-04-06"
+updated: "2026-04-08"
 tags: [moc, latent-communication]
 ---
 
@@ -10,43 +10,15 @@ tags: [moc, latent-communication]
 
 How multiple LLM agents exchange information through continuous representations rather than text. Natural language is optimized for human comprehension, not inter-model information transfer — every sampled token discards the model's full distributional belief. This research line explores progressively deeper channels that preserve more of that information.
 
-## The Depth Spectrum
-
-Communication methods form a spectrum from shallow (compatible, interpretable) to deep (information-dense, restrictive). For the full 10-level walkthrough with detailed analysis of each level, see **[[communication-depth-spectrum]]**. Navigate by depth below:
-
-### Embedding Level — Output-layer representations
-The shallowest continuous channel. Transmit weighted averages of token embeddings instead of sampled tokens.
-
-- **[[cipher-multiagent-debate-embeddings]]** — CIPHER: the foundational paper. Weighted output embeddings in debate, 0.5–5% gains. Requires shared tokenizer.
-- **[[state-delta-trajectory]]** — SDE: inter-token hidden-state *deltas* as steering vectors. Deltas outperform raw states. Same-model only.
-- **[[embedding-space-communication]]** — Concept synthesis: information bottleneck theory, convex hull constraint, full 10-level depth spectrum.
-
-### Activation Level — Hidden-state representations
-Share intermediate transformer activations — richer than embeddings, but harder to align across architectures.
-
-- **[[activation-communication-harvard]]** — AC: single-layer activation replacement at layer ~26, <¼ compute. Works cross-family (LLaMA/Qwen/Gemma).
-- **[[interlat-latent-space-agents]]** — Interlat: full hidden-state sequences, $2600\times$ bandwidth vs text. Cross-family with learned adapters.
-- **[[activation-communication]]** — Concept synthesis: 5-paper comparison, cross-model compatibility spectrum, information concentration problem.
-
-### KV-Cache Level — Attention memory
-Inject the sender's cached key-value pairs into the receiver's attention mechanism. The receiver attends to the sender's context as if it had processed it directly.
-
-- **[[kvcomm-selective-kv-sharing]]** — KVComm: layer selection, 30% of layers $\approx$ full performance.
-- **[[cache-to-cache-semantic-communication]]** — C2C: learned cross-architecture fusion with gating.
-- **[[kv-cache-alignment-shared-space]]** — KV Alignment: global shared space, $O(N)$ scaling, self-improvement effect.
-- **[[kvcomm-online-cross-context]]** — KVCOMM-online: anchor-based offset reuse, 7.8× speedup.
-- **[[kv-cache-communication]]** — Concept synthesis: 4 design dimensions, combined stack vision.
-
-### Structured Level — Disentangled thought representations
-Impose structure on the communicated representations — decompose into shared/private components with identifiability guarantees.
-
-- **[[thought-communication-multiagent]]** — ThoughtComm: disentangled thoughts, agreement routing, scales positively with debate rounds.
-- **[[thought-structure]]** — Shared/private decomposition, agreement routing.
-- **[[latent-variable-model]]** — Identifiability theory underpinning ThoughtComm.
+This MOC is the **thematic hub** for latent communication: concepts, entities, and theoretical foundations. For the paper-by-paper walkthrough by depth, see **[[communication-depth-spectrum]]**.
 
 ## Cross-Cutting Concepts
 
 - **[[continuous-vs-discrete-representation]]** — The theoretical foundation: why continuous > discrete for inter-model transfer.
+- **[[embedding-space-communication]]** — Output-layer synthesis: information bottleneck theory, convex hull constraint.
+- **[[activation-communication]]** — Hidden-state synthesis: 5-paper comparison, cross-model compatibility spectrum, information concentration problem.
+- **[[kv-cache-communication]]** — KV-cache synthesis: 4 design dimensions, combined stack vision.
+- **[[thought-structure]]** — Shared/private decomposition, agreement routing.
 - **[[multiagent-debate]]** — The debate paradigm these communication methods plug into.
 - **[[temperature-diversity]]** — Anchor/explorer dynamics and diversity's role in embedding-space debate.
 
@@ -57,12 +29,14 @@ Impose structure on the communicated representations — decompose into shared/p
 - **[[google-deepmind]]** — KV Cache Alignment
 - **[[cmu]]** — ThoughtComm
 - **[[fair-meta]]** — CIPHER ecosystem (LLaMA family enables shared-tokenizer communication)
+- **[[harvard]]** — AC (activation communication)
 
 ## Theoretical Foundations
 
 - **[[platonic-representation-hypothesis]]** — Why cross-family activation communication works: models converge to shared statistical structure.
 - **[[relative-representations-zero-shot]]** — Zero-shot model stitching via cosine-similarity anchors.
 - **[[linearity-relation-decoding]]** — Linear relational embeddings; explains enriched entity representations at mid-layers.
+- **[[latent-variable-model]]** — Identifiability theory underpinning ThoughtComm.
 
 ## Connections
 

--- a/wiki/sources/communication/activations/activation-communication-harvard.md
+++ b/wiki/sources/communication/activations/activation-communication-harvard.md
@@ -3,7 +3,6 @@ type: source
 title: "Communicating Activations Between Language Model Agents"
 source_file: "[[raw/pdf/arxiv-2501.14082.pdf]]"
 latex_source: "[[raw/latex/arxiv-2501.14082.tar.gz]]"
-venue_pdfs: ["[[raw/pdf/openreview-W6RPXUUFic.pdf|OpenReview]]"]
 author: "Vignav Ramesh, Kenneth Li"
 date_published: "2025-01-24"
 date_ingested: "2026-04-06"
@@ -49,7 +48,7 @@ The paper provides a 2D contour plot scanning all $(k,j)$ pairs $\in \{1,\ldots,
 - **Mid-late layers (~20-26)**: "Enriched entity representations" — entities in the prompt have been populated with additional facts about them from the model's weights. This is the **richest** representation of the input.
 - **Final layers (27-32)**: Representations are optimized for next-token prediction — information not needed for that narrow objective is discarded. Richer contextual knowledge is "thrown away."
 
-This layer-depth finding aligns with [[kvcomm-selective-kv-sharing|KVComm]]'s hypothesis H1 (intermediate layers encode the most transferable semantic knowledge), despite the two papers approaching the problem from different angles.
+This layer-depth finding aligns with [[kvcomm-kth-selective|KVComm]]'s hypothesis H1 (intermediate layers encode the most transferable semantic knowledge), despite the two papers approaching the problem from different angles.
 
 ## Key Results
 
@@ -155,7 +154,7 @@ AC introduces a critical distinction: **what matters is not just the depth of re
 
 - **[[activation-communication]]**: This is the **definitive empirical paper** for the concept. It validates that raw activation transfer works, identifies the optimal layer depth (mid-late), establishes the enriched entity representation theory, and demonstrates cross-family communication without learned projections.
 - **[[cipher-multiagent-debate-embeddings|CIPHER]]**: AC communicates a "strict superset" of CIPHER's information. CIPHER uses probability-weighted output embeddings; AC uses intermediate activations that encode richer information. AC also saves compute (partial forward pass vs. CIPHER's full sequential generation).
-- **[[kvcomm-selective-kv-sharing|KVComm]]**: Both find that intermediate layers are most informative for communication. KVComm found hidden states suffer from information concentration bias on the last token; AC confirms this but argues replace-at-one-layer is sufficient because B retains its own representations at other positions. KVComm advocates for KV pairs (attention-native integration); AC advocates for residual-stream activations (richer per position, but more invasive replacement).
+- **[[kvcomm-kth-selective|KVComm]]**: Both find that intermediate layers are most informative for communication. KVComm found hidden states suffer from information concentration bias on the last token; AC confirms this but argues replace-at-one-layer is sufficient because B retains its own representations at other positions. KVComm advocates for KV pairs (attention-native integration); AC advocates for residual-stream activations (richer per position, but more invasive replacement).
 - **[[state-delta-trajectory|SDE]]**: SDE refines AC's approach for same-model settings by using **deltas** (inter-token differences) instead of raw states, avoiding context contamination. AC works cross-model; SDE works same-model only.
 - **[[interlat-latent-space-agents|Interlat]]**: Extends AC from single-vector replacement to full-sequence hidden-state transmission with a learned communication adapter.
 - **[[continuous-vs-discrete-representation]]**: AC provides the clearest empirical case that continuous activations beat discrete text at a fraction of the compute.

--- a/wiki/sources/communication/activations/interlat-latent-space-agents.md
+++ b/wiki/sources/communication/activations/interlat-latent-space-agents.md
@@ -3,7 +3,6 @@ type: source
 title: "Enabling Agents to Communicate Entirely in Latent Space"
 source_file: "[[raw/pdf/arxiv-2511.09149.pdf]]"
 latex_source: "[[raw/latex/arxiv-2511.09149.tar.gz]]"
-venue_pdfs: ["[[raw/pdf/openreview-rmYbgsehTd.pdf|OpenReview]]"]
 author: "Zhuoyun Du, Runze Wang, Huiyu Bai, Zouying Cao, Xiaoyong Zhu, Yu Cheng, Bo Zheng, Wei Chen, Haochao Ying"
 date_published: "2025-11-14"
 date_ingested: "2026-04-06"

--- a/wiki/sources/communication/embeddings/cipher-multiagent-debate-embeddings.md
+++ b/wiki/sources/communication/embeddings/cipher-multiagent-debate-embeddings.md
@@ -3,7 +3,6 @@ type: source
 title: "Let Models Speak Ciphers: Multiagent Debate through Embeddings"
 source_file: "[[raw/pdf/arxiv-2310.06272.pdf]]"
 latex_source: "[[raw/latex/arxiv-2310.06272.tar.gz]]"
-venue_pdfs: ["[[raw/pdf/openreview-sehRvaIPQQ.pdf|OpenReview]]"]
 author: "Chau Pham, Boyi Liu, Yingxiang Yang, Zhengyu Chen, Tianyi Liu, Jianbo Yuan, Bryan A. Plummer, Zhaoran Wang, Hongxia Yang"
 date_published: "2023-10-10"
 date_ingested: "2026-04-06"

--- a/wiki/sources/communication/embeddings/state-delta-trajectory.md
+++ b/wiki/sources/communication/embeddings/state-delta-trajectory.md
@@ -3,7 +3,6 @@ type: source
 title: "Augmenting Multi-Agent Communication with State Delta Trajectory"
 source_file: "[[raw/pdf/arxiv-2506.19209.pdf]]"
 latex_source: "[[raw/latex/arxiv-2506.19209.tar.gz]]"
-venue_pdfs: ["[[raw/pdf/acl-2025.emnlp-main.518.pdf|EMNLP 2025]]"]
 author: "Yichen Tang, Weihang Su, Yujia Zhou, Yiqun Liu, Min Zhang, Shaoping Ma, Qingyao Ai"
 date_published: "2025-06-23"
 date_ingested: "2026-04-06"

--- a/wiki/sources/communication/kv-cache/cache-to-cache-semantic-communication.md
+++ b/wiki/sources/communication/kv-cache/cache-to-cache-semantic-communication.md
@@ -3,7 +3,6 @@ type: source
 title: "Cache-to-Cache: Direct Semantic Communication Between Large Language Models"
 source_file: "[[raw/pdf/arxiv-2510.03215.pdf]]"
 latex_source: "[[raw/latex/arxiv-2510.03215.tar.gz]]"
-venue_pdfs: ["[[raw/pdf/openreview-LeatkxrBCi.pdf|OpenReview]]"]
 author: "Tianyu Fu, Zihan Min, Hanling Zhang, Jichao Yan, Guohao Dai, Wanli Ouyang, Yu Wang"
 date_published: "2025-10-04"
 date_ingested: "2026-04-06"
@@ -18,7 +17,7 @@ tags: [kv-cache, cross-model, learned-fusion, multi-llm]
 
 ## Summary
 
-**Cache-to-Cache (C2C)**, from [[tsinghua|Tsinghua University]] and collaborators, proposes a learned neural cache fuser that projects and merges the KV-cache from a source ("Sharer") model into the representation space of a target ("Receiver") model. Unlike [[kvcomm-selective-kv-sharing|KVComm]]'s training-free concatenation (which requires same-architecture models), C2C's learned fuser enables communication across **different model families and sizes** — Qwen to LLaMA, 0.6B to 14B, general to specialized. This is the first approach to enable cross-architecture [[kv-cache-communication]].
+**Cache-to-Cache (C2C)**, from [[tsinghua|Tsinghua University]] and collaborators, proposes a learned neural cache fuser that projects and merges the KV-cache from a source ("Sharer") model into the representation space of a target ("Receiver") model. Unlike [[kvcomm-kth-selective|KVComm]]'s training-free concatenation (which requires same-architecture models), C2C's learned fuser enables communication across **different model families and sizes** — Qwen to LLaMA, 0.6B to 14B, general to specialized. This is the first approach to enable cross-architecture [[kv-cache-communication]].
 
 ## Oracle Experiments: Why KV-Cache Communication Works
 
@@ -153,17 +152,17 @@ The two approaches are potentially complementary: KV Cache Alignment's shared sp
 
 ## Limitations
 
-- **Requires training the fuser**: Unlike [[kvcomm-selective-kv-sharing|KVComm]] (training-free), C2C requires training a per-pair fuser module. Training cost depends on embedding dimension, not model parameter count (efficient), but still adds overhead.
+- **Requires training the fuser**: Unlike [[kvcomm-kth-selective|KVComm]] (training-free), C2C requires training a per-pair fuser module. Training cost depends on embedding dimension, not model parameter count (efficient), but still adds overhead.
 - **One fuser per model pair**: A fuser trained for Qwen→LLaMA may not transfer to Qwen→Gemma. The number of fusers scales as $O(N^2)$ with the number of model pair combinations, motivating [[kv-cache-alignment-shared-space|KV Cache Alignment]]'s $O(N)$ shared-space alternative.
 - **Alignment heuristics**: Token and layer alignment use heuristics (string-based matching, terminal alignment) that may lose information in edge cases. Learned alignment (e.g., via attention-based token matching) could improve robustness.
 - **No multi-round communication**: C2C is evaluated in a single-round Sharer→Receiver setting, not iterative debate. Whether the fuser remains effective when the Receiver's cache has already been fused in a prior round is unknown.
-- **No layer selection integration**: C2C's learnable gate decides per-layer whether to fuse, but does not incorporate [[kvcomm-selective-kv-sharing|KVComm]]'s attention-importance scoring. Combining the two signals (learned gating + calibration-based selection) could improve both efficiency and quality.
+- **No layer selection integration**: C2C's learnable gate decides per-layer whether to fuse, but does not incorporate [[kvcomm-kth-selective|KVComm]]'s attention-importance scoring. Combining the two signals (learned gating + calibration-based selection) could improve both efficiency and quality.
 
 ## Position in the KV-Cache Communication Cluster
 
 C2C addresses **how to fuse across architectures** — the cross-model projection problem. It pairs with:
-- [[kvcomm-selective-kv-sharing|KVComm]]: which addresses **what to share** (layer selection for same-architecture models)
-- [[kvcomm-online-cross-context|KVCOMM-online]]: which addresses **how to make sharing efficient** (cache reuse via offset estimation)
+- [[kvcomm-kth-selective|KVComm]]: which addresses **what to share** (layer selection for same-architecture models)
+- [[kvcomm-duke-online-reuse|KVCOMM-online]]: which addresses **how to make sharing efficient** (cache reuse via offset estimation)
 
 The three papers together cover complementary dimensions of [[kv-cache-communication]].
 

--- a/wiki/sources/communication/structured/thought-communication-multiagent.md
+++ b/wiki/sources/communication/structured/thought-communication-multiagent.md
@@ -3,7 +3,6 @@ type: source
 title: "Thought Communication in Multiagent Collaboration"
 source_file: "[[raw/pdf/arxiv-2510.20733.pdf]]"
 latex_source: "[[raw/latex/arxiv-2510.20733.tar.gz]]"
-venue_pdfs: ["[[raw/pdf/openreview-tq9lyV9Cml.pdf|OpenReview]]"]
 author: "Yujia Zheng, Zhuokai Zhao, Zijian Li, Yaqi Xie, Mingze Gao, Lizhu Zhang, Kun Zhang"
 date_published: "2025-10-23"
 date_ingested: "2026-04-06"

--- a/wiki/sources/reasoning/coconut-reasoning-latent-space.md
+++ b/wiki/sources/reasoning/coconut-reasoning-latent-space.md
@@ -3,7 +3,6 @@ type: source
 title: "Training Large Language Models to Reason in a Continuous Latent Space"
 source_file: "[[raw/pdf/arxiv-2412.06769.pdf]]"
 latex_source: "[[raw/latex/arxiv-2412.06769.tar.gz]]"
-venue_pdfs: ["[[raw/pdf/openreview-Itxz7S4Ip3.pdf|OpenReview]]"]
 author: "Shibo Hao, Sainbayar Sukhbaatar, DiJia Su, Xian Li, Zhiting Hu, Jason Weston, Yuandong Tian"
 date_published: "2024-12-09"
 date_ingested: "2026-04-06"

--- a/wiki/sources/reasoning/softcot-efficient-reasoning.md
+++ b/wiki/sources/reasoning/softcot-efficient-reasoning.md
@@ -3,7 +3,6 @@ type: source
 title: "SoftCoT: Soft Chain-of-Thought for Efficient Reasoning with LLMs"
 source_file: "[[raw/pdf/arxiv-2502.12134.pdf]]"
 latex_source: "[[raw/latex/arxiv-2502.12134.tar.gz]]"
-venue_pdfs: ["[[raw/pdf/acl-2025.acl-long.1137.pdf|ACL 2025]]"]
 author: "Yige Xu, Xu Guo, Zhiwei Zeng, Chunyan Miao"
 date_published: "2025-02-17"
 date_ingested: "2026-04-06"

--- a/wiki/sources/unified/vision-wormhole-heterogeneous.md
+++ b/wiki/sources/unified/vision-wormhole-heterogeneous.md
@@ -3,7 +3,6 @@ type: source
 title: "The Vision Wormhole: Latent-Space Communication in Heterogeneous Multi-Agent Systems"
 source_file: "[[raw/pdf/arxiv-2602.15382.pdf]]"
 latex_source: "[[raw/latex/arxiv-2602.15382.tar.gz]]"
-venue_pdfs: ["[[raw/pdf/openreview-xTh4AwVKdw.pdf|OpenReview]]"]
 author: "Xiaoze Liu, Ruowang Zhang, Weichen Yu, Siheng Xiong, Liu He, Feijie Wu, Hoin Jung, Matt Fredrikson, Xiaoqian Wang, Jing Gao"
 date_published: "2026-02-17"
 date_ingested: "2026-04-06"


### PR DESCRIPTION
## Summary

Two-part redundancy cleanup completing the audit started today. The KVComm rename landed separately as #2; the workflow refinements codifying the audit landed as #3. This PR covers the remaining wiki/source edits.

- **Phantom venue PDFs pruned (9 source pages).** Strips `venue_pdfs:` frontmatter from the 9 source pages still carrying broken OpenReview/ACL references after #2 merged: `coconut-reasoning-latent-space`, `softcot-efficient-reasoning`, `cipher-multiagent-debate-embeddings`, `state-delta-trajectory`, `activation-communication-harvard`, `interlat-latent-space-agents`, `cache-to-cache-semantic-communication`, `thought-communication-multiagent`, `vision-wormhole-heterogeneous`. The two `kvcomm-*` source pages and `raw/index.md` were already pruned via #2.
- **MOC overlap collapsed.** `wiki/mocs/latent-communication.md` reduced from 71 → 45 lines: removes the paper-by-paper depth section that duplicated `communication-depth-spectrum`, keeps the unique cross-cutting concepts, key entities, theoretical foundations, and connections sections. The two MOCs are now orthogonal — `latent-communication` is the thematic hub, `communication-depth-spectrum` is the paper walkthrough.
- **Side-effect: in-prose backlink fix.** PR #2's merge left two source pages with stale `[[kvcomm-selective-kv-sharing|...]]` / `[[kvcomm-online-cross-context|...]]` references in body prose. This PR rewrites them in `activation-communication-harvard.md` and `cache-to-cache-semantic-communication.md`. Historical `wiki/log.md` entries containing the old slugs are intentionally unchanged (point-in-time records).

11 files changed, 27 insertions, 50 deletions.

## Test plan

- [ ] `git grep 'kvcomm-selective-kv-sharing\|kvcomm-online-cross-context' -- ':!wiki/log.md'` returns no matches.
- [ ] `git grep 'venue_pdfs:' -- 'wiki/sources/'` returns no matches.
- [ ] `git grep 'openreview-\|acl-2025\.'` returns only the forward-looking note in `raw/index.md` and the `AGENTS.md` schema doc.
- [ ] `wiki/mocs/latent-communication.md` renders cleanly in Obsidian; the new pointer to `[[communication-depth-spectrum]]` resolves.
- [ ] No accidental edits to `.obsidian/graph.json`, `.codex/`, `.mcp.json`, or to any of the in-progress files in the working tree.