### PR TITLE
chore: gitignore local agent and tooling state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ __pycache__/
 *.bak
 *.swp
 *~
+
+# Local agent / tooling state
+.codex/
+.mcp.json


### PR DESCRIPTION
## Summary

Add `.codex/` and `.mcp.json` to `.gitignore` so local agent/tooling state stops appearing in `git status` and the source-control panel.

- **`.codex/config.toml`** — Codex CLI's per-user config.
- **`.mcp.json`** — MCP server config containing a Windows-specific absolute path (`C:\Users\timot\.local\bin\arxiv-mcp-server.exe`) to a local binary, so it cannot be shared across contributors.

Neither file is currently tracked, so no `git rm --cached` is needed. This is a pure `.gitignore` addition that keeps them out of `git status` going forward. If another contributor (or another machine) sets up their own MCP config or Codex install, theirs will also be ignored automatically.

## Test plan

- [ ] After merge, `git status` on a fresh clone with a `.codex/` or `.mcp.json` present shows zero entries from those paths.
- [ ] Existing untracked entries in your local working tree disappear from the source-control panel.
- [ ] No previously-tracked files become ignored (the patterns only match files that were never committed).