### PR TITLE
refactor(workflows): PR 2a — extract 14 shared fragments + retrofit entity-partials

### DIFF
--- a/workflows/_shared/glossary.md
+++ b/workflows/_shared/glossary.md
@@ -1,0 +1,100 @@
+# Glossary
+
+Canonical names for concepts that have drifted across existing workflows. Workflows MUST use the canonical term in new prose. The lint workflow's terminology check (expected, PR 2b) flags drift variants for normalization.
+
+This glossary expands the seed in [`../CONVENTIONS.md`](../CONVENTIONS.md). When you add a new term, add it here and remove it from the seed. The seed is being deprecated in favor of this fragment.
+
+## Terms
+
+### living analyses
+
+**Drift variants:** "gap-tracking analysis pages", "analysis pages", "synthesis pages"
+
+**Definition:** The 6+ files under `wiki/analyses/` that must be checked on every ingest because they synthesize claims across multiple papers. New papers regularly update individual numbered tensions, directions, or rows inside these files, so they require per-item review (see [`procedures/living-analyses-review.md`](procedures/living-analyses-review.md)).
+
+**Notes:** "synthesis pages" is too broad — it would also include `wiki/overview-state-of-field.md`, which is not a living analysis. Always use "living analyses" when you specifically mean the per-item-review enumeration.
+
+### source page
+
+**Drift variants:** "source summary page", "source file page"
+
+**Definition:** A markdown page under `wiki/sources/**/` that summarizes a single paper. Has frontmatter `type: source` and the per-source schema in [`rules/frontmatter-schema.md`](rules/frontmatter-schema.md).
+
+**Notes:** `ingest.md` historically mixed "source summary page" and "source page" in the same procedure. Standardize on "source page".
+
+### MOC
+
+**Drift variants:** none — but commonly conflated with "reading path"
+
+**Definition:** A *Map of Content* file at `wiki/mocs/<theme>.md`. Each MOC defines a curated traversal of the wiki for a specific theme.
+
+**Important:** "MOC" is the **file**. "Reading path" (see next term) is the **ordered traversal baked into the MOC's body**. They are not synonyms — the MOC has metadata and prose around its reading path, and a single MOC has exactly one reading path. Conflating the two leads to ambiguous procedure language ("update the MOC" vs "update the reading path") that has caused real bugs.
+
+### reading path
+
+**Drift variants:** "reading path outline", "MOC reading path", and (incorrectly) "MOC"
+
+**Definition:** The ordered sequence of pages baked into a MOC's body. The order matters — each MOC declares an ordering principle (chronological, conceptual progression, mechanism-first, etc.) in its header, and entries are inserted in the position the principle dictates, not appended at the end.
+
+**Notes:** When you say "update the MOC", be explicit about whether you mean the file as a whole (prose, header, ordering principle) or the reading path inside it.
+
+### coordinator-only files
+
+**Drift variants:** "shared files", "off-limits for agents", "do-not-touch files"
+
+**Definition:** The set of files that subagents launched in parallel from a workflow MUST NOT edit. The canonical enumeration lives in [`rules/shared-file-off-limits.md`](rules/shared-file-off-limits.md).
+
+**Notes:** Avoid "shared files" because it is ambiguous with the `_shared/` fragment directory. "Coordinator-only" is unambiguous and signals the underlying rule (the coordinator is the only allowed writer).
+
+### thin pages / below depth standard
+
+**Drift variants:** "shallow pages", "stub pages", "pages needing expansion"
+
+**Definition:** Pages whose content falls below the depth standard for their type. The depth standard is documented per-type in `AGENTS.md` (and the upcoming `_shared/checklists/base.md` in PR 2b).
+
+**Notes:** Both "thin pages" and "below depth standard" are acceptable — they differ in register, not meaning. Prefer "thin pages" in procedure step language for brevity, and "below depth standard" in checklist and audit contexts where precision matters.
+
+### phantom assets / phantom paths
+
+**Drift variants:** "stale paths", "dead references" (when applied to file paths specifically)
+
+**Definition:** A file path written into the wiki (in frontmatter, body wiki-links, indexes, or checklists) that does not actually point to a file on disk. See [`rules/path-discipline.md`](rules/path-discipline.md) for the rule that forbids these.
+
+**Notes:** "phantom" is the canonical term and is well-named — it captures both that the path looks valid and that the underlying file is absent. Use "phantom" rather than "stale" or "dead", which have other meanings (stale = outdated, dead = orphaned).
+
+### stale claim
+
+**Drift variants:** "outdated claim", "superseded claim"
+
+**Definition:** A factual claim in a wiki page that newer evidence has invalidated or refined. The lint workflow's content-integrity scan looks for these.
+
+**Notes:** A stale claim is *content* that has been superseded; a phantom path is a *file reference* that does not resolve. They are different regression classes and should not be conflated.
+
+### orphan page
+
+**Drift variants:** "unlinked page", "isolated page"
+
+**Definition:** A page with no inbound wiki-links from any other page in the vault. Lint flags these because they are unreachable through navigation even though they exist in `wiki/index.md`.
+
+**Notes:** A page that is referenced only from `wiki/index.md`'s directory tree counts as an orphan. The directory tree is an inventory, not a navigation surface.
+
+### red link
+
+**Drift variants:** "broken link", "missing page link"
+
+**Definition:** A `[[wiki-link]]` whose target file does not exist. Lint flags these as part of the content-integrity scan.
+
+**Notes:** "Red link" is borrowed from MediaWiki convention and is unambiguous. Avoid "broken link" (which can also mean a malformed URL) and "missing page link" (clumsy).
+
+## How this glossary is enforced
+
+- **Authoring time:** Workflows reference this glossary when introducing new prose. Use the canonical term, not a drift variant.
+- **Lint time:** The lint workflow's terminology check (expected, PR 2b) greps for drift variants and flags them for normalization.
+- **Review time:** The review workflow surfaces drift variants in its findings list.
+
+## Used by
+
+- `workflows/CONVENTIONS.md` (the seed glossary will be removed once this fragment is referenced from the main workflows; until then, both exist with this fragment as the canonical source)
+- `workflows/lint.md` (expected, PR 2b — terminology check)
+- `workflows/review.md` (expected, PR 2b — terminology drift in findings)
+- All workflow files (expected, PR 2b — every workflow that uses any term in this glossary should use the canonical form)

--- a/workflows/_shared/procedures/bulk-source-rename.md
+++ b/workflows/_shared/procedures/bulk-source-rename.md
@@ -1,0 +1,42 @@
+# Bulk Source-Page Rename
+
+## Purpose
+
+When a source page slug changes (e.g., to disambiguate after a slug-collision audit), every backlink in the wiki must be updated atomically. The surface area of backlinks is large enough that editing one file at a time virtually guarantees a missed link, and a single missed link breaks navigation. This fragment defines the exact sequence — including the one place in the wiki where `sed` is the blessed tool — so renames stay consistent and history-preserving.
+
+## When to run
+
+- After a slug-collision audit triggers a rename (`workflows/lint.md` Redundancy & Dead-Reference Audit, section C).
+- Any time a source page's filename slug needs to change for any reason.
+- Never as a one-off shortcut for a content change — this is rename-only; if the page itself needs revision, do that as a separate edit.
+
+## Procedure
+
+1. **Enumerate references first**: `Grep '\[\[<old-slug>' .` — confirm the count and the files affected. This is the inventory you will verify against in step 4.
+2. **Move the file with `git mv`** so history is preserved. Never use `Write` to create a new file alongside the old; that orphans the rename from git history and forces a manual fix later.
+3. **Bulk-rewrite all references**. The blessed tool for this single case is `sed` (the only place in the project where `sed` overrides the "use Edit, not sed" default), because (a) the slug is unique enough that collateral damage is impossible to introduce, and (b) the alternative is 30+ Read+Edit pairs:
+
+   ```bash
+   find wiki raw -name "*.md" -print0 | xargs -0 sed -i 's/<old-slug>/<new-slug>/g'
+   ```
+
+4. **Verify**: re-run `Grep '<old-slug>' .` — must return zero matches. Any non-zero result means the inventory step missed a file, and the rewrite must be extended to cover it.
+5. **Update `raw/index.md`** if the source page is also referenced there (the sed pass usually handles this — confirm by inspection).
+6. **Log it** in `wiki/log.md` with action `lint` or `update`, listing both the old and new slugs so the rename is auditable later.
+
+## Invariants
+
+- `git mv`, never `Write`. History preservation is non-negotiable.
+- `sed` is the blessed tool for this single rename pattern — and only this pattern. Anywhere else in the project, the "use Edit, not sed" default applies.
+- The post-rewrite `Grep '<old-slug>' .` must return zero matches before the procedure is considered complete. Any non-zero result is a regression, not a "good enough" outcome.
+- Both the old slug and the new slug must appear in the `wiki/log.md` entry so future audits can trace the rename.
+- This procedure is rename-only. Do not bundle it with content edits to the renamed page; mixing the two makes the diff unreadable and the history confusing.
+
+## After completion
+
+Return to the calling workflow and proceed with its next numbered step. This fragment is a subroutine — it has no terminal action of its own, and its caller's remaining steps (any further audit findings, fixes, log entry, report) are not optional just because the rename is complete.
+
+## Used by
+
+- `workflows/lint.md` (expected, PR 2b — Redundancy & Dead-Reference Audit, section C, replacing the inlined "Bulk source-page rename" section)
+- `workflows/enrich.md` (expected, PR 2b — when a slug change is part of the pass)

--- a/workflows/_shared/procedures/commit-and-push.md
+++ b/workflows/_shared/procedures/commit-and-push.md
@@ -1,0 +1,57 @@
+# Commit and Push
+
+## Purpose
+
+Uncommitted work is fragile — it can be lost to a tab crash, an accidental `git restore`, or a context-window reset on the next session. Workflow changes deserve explicit review even when research changes are routine. This fragment encodes both disciplines: research files ship straight to `master` because they are content-only and the user reviews them continuously through the wiki, while workflow files go through a feature-branch + PR review surface because they shape every future ingest. The split is based on **blast radius**.
+
+## When to run
+
+- At the end of any ingest, batch-ingest, gap-analysis, enrich, expand, synthesize, or audit pass that produced commitable changes.
+- Whenever a workflow's procedure says to commit and push.
+- Never as a freestanding action — this fragment is always invoked from a calling workflow whose remaining steps (log entry, report) it does not own.
+
+## Procedure
+
+1. **Identify which files belong to which bucket** before staging anything. Walk the output of `git status` and classify each modified file:
+   - **Research bucket** (commit on `master`): `wiki/**`, `raw/**`, `README.md`, anything created or updated by the workflow itself.
+   - **Workflow bucket** (PR): `workflows/**`, `AGENTS.md` (if the workflow index changed), and any new schema or process documentation.
+   - **Do not touch**: any modified file you did *not* write to during this session. Pre-existing in-progress work in the working tree must not be staged. The session-start `git status` (captured in the system context) is the source of truth for what was already dirty before you began.
+
+2. **Stage the research files explicitly by path**, not with `git add -A` or `git add .`. Explicit paths prevent accidentally staging the user's pre-existing in-progress work, the `.codex/` or `.mcp.json` shells, or `.obsidian/graph.json` auto-saves. Verify with `git status` that the staged set matches your research bucket exactly and that any workflow files remain unstaged.
+
+3. **Commit on `master`** with a descriptive message that names the work, summarizes the contribution, lists created/updated pages, and notes any cleanup work bundled in (e.g., paper-count sweeps, checklist resync). Follow the existing repo style — run `git log --oneline -5` to compare. Always include the `Co-Authored-By` trailer.
+
+4. **Push `master`** to `origin`. The research commit is now durable.
+
+5. **If workflow files were also touched**, create a PR for them — do not commit workflow changes directly to `master`:
+   1. `git checkout -b workflow-<short-descriptor>` (e.g. `workflow-improvements-gap-analysis-discipline`). The branch starts from current `master` so the unstaged workflow changes carry over automatically.
+   2. Stage the workflow files explicitly (`workflows/*.md` and any related schema files).
+   3. Commit on the branch with a message that explains the **regression class** the workflow change prevents, not just the line-level diff. (E.g. "Add per-direction analysis review + count-drift sweep + checklist sync to ingest workflow" with a body explaining what was missed in the most recent run.)
+   4. `git push -u origin <branch>`.
+   5. `gh pr create --title "..." --body "..."` with a body that includes a Summary section (regression classes addressed) and a Test plan section (how to verify the new instructions work on the next ingest).
+   6. Return to `master` (`git checkout master`) so subsequent work does not accidentally land on the PR branch.
+
+6. **If only research files were touched**, skip step 5 — no PR needed.
+
+## Invariants
+
+- **Research → master, workflows → PR.** This split is non-negotiable. Workflow changes shape every future ingest and benefit from a PR review surface even when the author is the same.
+- **Stage by explicit path.** `git add -A` and `git add .` are forbidden. They have, in past sessions, swept up pre-existing in-progress work, `.codex/`, `.mcp.json`, and `.obsidian/graph.json`.
+- **Pre-existing dirty files are off-limits.** The session-start `git status` is the source of truth for what was already dirty. Anything in that snapshot must not be staged by this workflow's commit.
+- **The `Co-Authored-By` trailer is mandatory** on every commit produced by an agent-driven workflow.
+- **PR commit messages explain regression classes**, not line-level diffs. The reviewer needs to understand *why* the workflow needed the change.
+- **Never `--no-verify` and never `--no-gpg-sign`** unless the user has explicitly asked for it. If a hook fails, investigate the underlying issue.
+- **Never amend a published commit.** If a hook fails after a successful commit, fix the issue and create a new commit; do not `--amend` and rewrite history that may already be elsewhere.
+
+## After completion
+
+Return to the calling workflow and proceed with its next numbered step. This fragment is a subroutine — it has no terminal action of its own, and the calling workflow's remaining steps (final report to user, any post-commit verification) are not optional just because the commit and push are done.
+
+## Used by
+
+- `workflows/ingest.md` (expected, PR 2b — Procedure step 15, replacing the current one-line pointer)
+- `workflows/batch-ingest.md` (expected, PR 2b — final consolidation step)
+- `workflows/gap-analysis.md` (expected, PR 2b — Phase 6, replacing the inlined long form that this fragment is sourced from)
+- `workflows/enrich.md` (expected, PR 2b — final step)
+- `workflows/synthesize.md` (expected, PR 2b — final step)
+- `workflows/enrichment-audit.md` (expected, PR 2b — Phase 4 final step)

--- a/workflows/_shared/procedures/entity-partials.md
+++ b/workflows/_shared/procedures/entity-partials.md
@@ -97,6 +97,10 @@ Future ingests that add a paper to an existing entity edit only `wiki/entities/<
 - Never extract narrative prose into a partial. Partials are structured data (tables, lists); narrative stays in the shell where it can be edited in context.
 - The partial subdirectory name must exactly equal the shell file's basename (minus `.md`). `wiki/entities/amazon.md` ↔ `wiki/entities/amazon/`.
 
+## After completion
+
+Return to the calling workflow and proceed with its next numbered step. This fragment is a subroutine — it has no terminal action of its own, and the calling workflow's remaining steps (index update, MOC update, raw asset sync, log entry, commit, report) are not optional just because the entity partial has been created or updated.
+
 ## Used by
 
 - `workflows/ingest.md` — when an ingest introduces a new entity or adds a paper to an existing entity's timeline.

--- a/workflows/_shared/procedures/moc-update.md
+++ b/workflows/_shared/procedures/moc-update.md
@@ -1,0 +1,35 @@
+# MOC Update
+
+## Purpose
+
+When a new source page is added to the wiki (via ingest or batch-ingest), the relevant MOC's reading path must be updated so the new page is reachable through navigation, not just through `wiki/index.md`. This fragment defines the lightweight per-ingest MOC update — distinct from a full MOC gap analysis (which decides whether new MOCs are needed) and distinct from MOC creation (which is its own workflow).
+
+## When to run
+
+- After a single-paper ingest, once the source page exists.
+- After each paper in a batch-ingest.
+- Any time a new page joins an existing theme that already has a MOC.
+
+## Procedure
+
+1. **Identify the relevant MOC(s).** A new source page typically belongs to one or two MOCs based on its theme. Open `wiki/mocs/` and pick the MOC whose reading path covers the new page's primary contribution. If the page contributes to multiple themes, update each MOC.
+2. **Add the new page to the MOC's reading path** in the position that respects the path's existing ordering principle (chronological, conceptual progression, mechanism-first, etc. — see the MOC's own header to determine which principle applies). Do not append to the end by default.
+3. **Update any prose descriptions in the MOC** that reference page counts, key papers, or thematic clusters that the new page changes. Watch for "5+ papers cover X" style sentences whose count would now drift.
+4. **Verify the `AGENTS.md` Current MOCs list still matches the actual `wiki/mocs/*.md` files** — this is a fast check (`Glob wiki/mocs/*.md` vs the AGENTS.md list) that catches the rare case where a MOC was accidentally created or deleted in the same session.
+
+## Invariants
+
+- A new source page must appear in at least one MOC's reading path before its ingest is considered complete. Pages that exist only in `wiki/index.md` are not navigable through the wiki's curated paths.
+- The reading path's existing ordering principle is load-bearing — do not insert the new page at the end by default. Position it where the ordering principle says it belongs.
+- Prose page counts inside MOC files must be updated to the new value at MOC-update time. Stale counts in MOC blurbs are also caught by the [stale count sweep](stale-count-sweep.md), but updating them here prevents the sweep from finding extra work and reduces the risk of two ingests racing on the same MOC count.
+- This fragment does not create new MOCs. If a theme has 5+ pages and no MOC, that is the job of `workflows/moc-gap-analysis.md`, not this procedure.
+- "MOC" and "reading path" are not synonyms. The MOC is the file; the reading path is the ordered traversal baked into the file's body. This procedure updates the reading path (and any prose around it) without creating a new file.
+
+## After completion
+
+Return to the calling workflow and proceed with its next numbered step. This fragment is a subroutine — it has no terminal action of its own, and its caller's remaining steps (raw/index update, analyses review, count sweep, log entry, commit, report) are not optional just because the MOC update is done.
+
+## Used by
+
+- `workflows/ingest.md` (expected, PR 2b — Procedure step 8)
+- `workflows/batch-ingest.md` (expected, PR 2b — once per ingested paper, before consolidation)

--- a/workflows/_shared/procedures/parallel-subagent-protocol.md
+++ b/workflows/_shared/procedures/parallel-subagent-protocol.md
@@ -1,0 +1,60 @@
+# Parallel Subagent Protocol
+
+## Purpose
+
+When a workflow dispatches work across multiple subagents (per-paper ingest, per-page review, per-task enrichment, per-MOC creation), the coordinator must enforce a strict isolation contract: subagents own only their assigned files, never touch coordinator-only files, and surface findings rather than silently fixing them. Without this protocol, parallel work race-conditions on shared indexes, double-edits MOCs, and produces irreproducible state. This fragment is the canonical isolation contract every parallel-subagent workflow must follow.
+
+The off-limits file enumeration in this fragment is the **complete** list. Earlier inlined copies in `batch-ingest.md`, `verification.md`, `moc-gap-analysis.md`, and `enrichment-audit.md` each listed a different subset (`raw/index.md` was missing from one, `AGENTS.md` was forbidden in only one, etc.). The drift introduced real bugs. The fragment reconciles them.
+
+## When to run
+
+- Before launching any parallel-subagent phase. The coordinator reads this fragment, applies the contract to its subagent prompts, and only then dispatches.
+- Inside `workflows/batch-ingest.md` (per-paper ingest agents).
+- Inside `workflows/verification.md` (per-page review agents — note: review agents return findings only, never edit).
+- Inside `workflows/moc-gap-analysis.md` (per-MOC creation agents).
+- Inside `workflows/enrichment-audit.md` Phase 3 (per-task enrichment agents).
+- Anywhere a workflow says "launch parallel subagents" or "dispatch in parallel".
+
+## Procedure
+
+1. **Decompose the work into independent units** before launching anything. A unit is independent if its files have no overlap with any other unit's files. Per-paper ingest, per-page review, per-task enrichment, and per-MOC creation are the canonical decompositions.
+
+2. **Write each subagent prompt with explicit scope boundaries.** Each prompt MUST include:
+   - The exact files the agent owns (read + write).
+   - The exact files the agent may read but never write (typically: source pages, references).
+   - The off-limits file list (see step 3).
+   - A clear instruction to **report** any need to touch an off-limits file rather than touching it.
+   - The agent's deliverable (a created page, a returned findings list, a checklist of completed sub-tasks).
+
+3. **Apply the canonical off-limits enumeration from [`../rules/shared-file-off-limits.md`](../rules/shared-file-off-limits.md).** That rule is the single source of truth for which files are coordinator-only. Subagents MUST NOT edit any file in the rule's enumeration; if they need to, they must surface the need to the coordinator and wait. The rule fragment lists the complete set and explains why each file is included; do not maintain a separate enumeration in this procedure or in any individual workflow.
+
+4. **Launch the subagents in parallel.** Use the `Agent` tool with `run_in_background: true` for genuinely independent work, or batch tool calls in a single message for foreground parallel execution.
+
+5. **Track completion incrementally.** Do not wait for all agents to finish before reporting. Surface per-agent completion to the user as it happens; this lets long-running phases stay observable.
+
+6. **After all subagents complete, run the [spot-check agent output](spot-check-agent-output.md) sub-procedure** before consolidation. The spot-check is the minimum trust-but-verify pass; if it escalates to full verification, run `workflows/verification.md` before consolidating shared files.
+
+7. **Consolidate shared files yourself, as the coordinator.** Update each off-limits file from step 3 with the aggregated outputs of the subagents. Stage and commit the consolidation as a single coherent change, not interleaved with subagent work.
+
+8. **Run the [stale count sweep](stale-count-sweep.md) and the [living analyses review](living-analyses-review.md)** if the parallel phase added or removed source pages. Both fragments are mandatory for any phase that changes the source-page count or touches analyses.
+
+## Invariants
+
+- **Subagents never edit off-limits files.** Violations of this rule have produced multi-hour cleanups in past sessions; the rule is non-negotiable.
+- **The off-limits enumeration in this fragment is canonical.** No workflow may inline a shorter list. If a new file becomes coordinator-only, add it here, not in individual workflows.
+- **Subagents report, coordinators consolidate.** This is the single most important habit for keeping parallel work auditable. A coordinator who lets subagents touch shared files is no longer running this protocol.
+- **Verification subagents are a special case** — they read pages and return findings, never edit. The off-limits list still applies; they simply have a stricter "no writes anywhere" constraint on top.
+- **Spot-check before consolidation, always.** Skipping the spot-check has, in past sessions, shipped numbers-off-by-small-amounts errors into the wiki that weren't caught for weeks.
+- **Stale count sweep + living analyses review run after consolidation, not before.** The sweep needs the post-consolidation count to be authoritative.
+
+## After completion
+
+Return to the calling workflow and proceed with its next numbered step. This fragment is a subroutine — it has no terminal action of its own, and the calling workflow's remaining steps (final consolidation reports, log entry, commit, user report) are not optional just because the parallel phase has completed.
+
+## Used by
+
+- `workflows/batch-ingest.md` (expected, PR 2b — Procedure step 2, replacing the inlined "Launch parallel subagents" enumeration)
+- `workflows/verification.md` (expected, PR 2b — Procedure step 3, "Run the content accuracy check in parallel")
+- `workflows/moc-gap-analysis.md` (expected, PR 2b — Procedure steps 8–11, "Use parallel subagents if creating 2+ MOCs")
+- `workflows/enrichment-audit.md` (expected, PR 2b — Phase 3, "Execute in Parallel")
+- `workflows/plugin-audit.md` (expected, PR 2b — Procedure step 3, "Bulk fix any issues found using parallel subagents")

--- a/workflows/_shared/procedures/raw-checklist-row.md
+++ b/workflows/_shared/procedures/raw-checklist-row.md
@@ -1,0 +1,50 @@
+# Raw Checklist Row
+
+## Purpose
+
+`raw/checklist.md` is the URL audit trail that runs parallel to `raw/index.md`'s asset map. Every arXiv paper listed in `raw/index.md`'s "Canonical PDFs" table must have exactly one corresponding row in `raw/checklist.md`. This fragment defines the eight-column row format and the per-column rules so callers append rows consistently and the bijection is never broken by ad-hoc formatting.
+
+## When to run
+
+- During an ingest, immediately after updating `raw/index.md` with the new PDF and LaTeX source.
+- During a batch-ingest, once per ingested arXiv paper.
+- Any time a new arXiv paper is added to `raw/index.md`'s Canonical PDFs table.
+
+## Procedure
+
+Append one row to `raw/checklist.md` with these eight columns:
+
+```
+Paper | Original refs from list | Canonical PDF download | Canonical LaTeX/source download | PDF present | Local PDF | LaTeX present | Local LaTeX/source
+```
+
+Fill each column as follows:
+
+1. **Paper** — the paper title.
+2. **Original refs from list** — `arXiv:XXXX.XXXXX` plus any venue-duplicate IDs (OpenReview, ACL, EMNLP, ICLR, NeurIPS, ICML) that appear in the "Duplicate PDFs (Venue Copies)" section of `raw/index.md` for this paper. Separate multiple refs with `;`. **Only include venue refs whose PDF is actually present in `raw/pdf/`** — verify each path with `Glob` before listing it, same constraint as the source page's `venue_pdfs:` frontmatter.
+3. **Canonical PDF download** — `https://arxiv.org/pdf/{id}` (use the bare ID, no version suffix unless intentionally pinning).
+4. **Canonical LaTeX/source download** — `https://arxiv.org/e-print/{id}`.
+5. **PDF present** — `Yes` once the downloader has run and `raw/pdf/arxiv-{id}.pdf` exists on disk.
+6. **Local PDF** — `raw/pdf/arxiv-XXXX.XXXXX.pdf`. **Do not use `reference/pdf/...`** — that is a stale historical path from a pre-move vault layout and has caused drift in the past.
+7. **LaTeX present** — `Yes` once the downloader has run and the LaTeX source exists on disk in either form.
+8. **Local LaTeX/source** — must match the actual on-disk format chosen in `raw/download_arxiv_papers.py`:
+   - `raw/latex/arxiv-XXXX.XXXXX/` (trailing slash) for `extract`-mode papers whose source was unpacked into a directory.
+   - `raw/latex/arxiv-XXXX.XXXXX.tar.gz` for `archive`-mode papers stored as a tarball.
+
+## Invariants
+
+- Every arXiv paper in `raw/index.md`'s "Canonical PDFs" table has exactly one row in `raw/checklist.md`. The bijection holds in both directions.
+- Non-arXiv sources (e.g., the latentcompress GitHub project) are intentionally excluded from the checklist.
+- `raw/pdf/...` and `raw/latex/...` are the only acceptable local-path prefixes. `reference/pdf/...` is a stale historical path that must never be reintroduced.
+- Venue refs in column 2 are only listed when their PDF is on disk in `raw/pdf/`. Phantom venue refs propagate into `raw/index.md` and break lint passes weeks later.
+- The `Local LaTeX/source` column format must match the actual download mode (`extract` → directory with trailing slash, `archive` → `.tar.gz` file). Mismatches break the asset bijection.
+
+## After completion
+
+Return to the calling workflow and proceed with its next numbered step. This fragment is a subroutine — it has no terminal action of its own, and its caller's remaining steps (analyses review, count sweep, log entry, commit, report) are not optional just because the row has been appended.
+
+## Used by
+
+- `workflows/ingest.md` (expected, PR 2b — Procedure step 10)
+- `workflows/batch-ingest.md` (expected, PR 2b — once per ingested paper)
+- `workflows/gap-analysis.md` (expected, PR 2b — Phase 5 ingest substep)

--- a/workflows/_shared/procedures/spot-check-agent-output.md
+++ b/workflows/_shared/procedures/spot-check-agent-output.md
@@ -1,0 +1,39 @@
+# Spot-Check Agent Output
+
+## Purpose
+
+Subagents working in parallel on a wiki workflow commonly make small but consequential mistakes — wrong file paths, imprecise claims, numbers off by small amounts, conflated findings from different papers, or stale frontmatter. This fragment defines the **lightweight spot-check** the coordinator runs after a parallel-subagent phase completes, before the work is treated as final. It is not a full verification pass (`workflows/verification.md` is the heavyweight workflow for that); it is the minimum trust-but-verify check every parallel workflow owes its own outputs.
+
+## When to run
+
+- Immediately after a parallel-subagent phase completes, before the consolidation phase that touches shared files.
+- Inside the `enrichment-audit.md` Phase 4 consolidation pass.
+- Inside the `batch-ingest.md` consolidation step.
+- Any time subagent output is about to be promoted to the wiki without the user having seen it page-by-page.
+
+## Procedure
+
+1. **Sample, do not exhaustively review.** Pick 2–3 pages from the agent output (or one per agent if there are few). Exhaustive review is the job of `workflows/verification.md`; this is the catch-the-obvious-stuff pass.
+2. **Check numbers.** For each sampled page, verify any quantitative claims (parameter counts, accuracy figures, paper years, benchmark scores) against the underlying source. Numbers off by small amounts are the most common subagent error and the easiest to miss in casual reading.
+3. **Check links.** For each `[[wiki-link]]` in the sampled pages, confirm the target file exists. Phantom wiki-links propagate quickly through indexes and break navigation.
+4. **Check frontmatter.** Confirm each sampled page has the required frontmatter fields per the canonical schema (`type:`, `title:`, `created:`, plus any type-specific fields). Subagents sometimes drop fields or use the wrong `type:` value.
+5. **Flag, do not silently fix.** If the spot check finds an issue, surface it back to the user (or the workflow's findings list) rather than editing the page in place. Silent fixes hide patterns of subagent error that would otherwise inform later workflows.
+6. **Decide whether to escalate.** If the spot check finds two or more issues across the sample, the parallel phase's output is suspect at scale and the workflow should escalate to a full verification pass via `workflows/verification.md` before the work is consolidated.
+
+## Invariants
+
+- This is a sampling check, not an exhaustive review. Do not let it expand into a per-page audit — that escalation belongs to `workflows/verification.md`.
+- Findings are flagged, not silently corrected. Silent fixes hide error patterns and prevent future workflows from learning where subagent failure modes cluster.
+- The escalation rule is non-negotiable: 2+ issues across the sample → full verification pass before consolidation. Treating "looks mostly fine" as good enough is how a bad parallel phase ships.
+- Numbers, links, and frontmatter are the three load-bearing categories. Other concerns (prose quality, redundancy, depth) belong to `workflows/review.md` and `workflows/enrich.md`, not this spot check.
+
+## After completion
+
+Return to the calling workflow and proceed with its next numbered step. This fragment is a subroutine — it has no terminal action of its own, and its caller's remaining steps (consolidation, log entry, report) are not optional just because the spot check is done. If the spot check escalated to full verification, the calling workflow must wait for verification to complete before resuming consolidation.
+
+## Used by
+
+- `workflows/enrichment-audit.md` (expected, PR 2b — Phase 4 step 4, replacing the inlined "Spot-check agent output" line)
+- `workflows/verification.md` (expected, PR 2b — as the entry-point lightweight check before the heavier per-page review subagents are dispatched)
+- `workflows/batch-ingest.md` (expected, PR 2b — after parallel ingest phase, before consolidation)
+- `workflows/moc-gap-analysis.md` (expected, PR 2b — after parallel MOC-creation subagents complete)

--- a/workflows/_shared/procedures/update-index-and-assets.md
+++ b/workflows/_shared/procedures/update-index-and-assets.md
@@ -1,0 +1,51 @@
+# Update Index and Assets
+
+## Purpose
+
+When wiki content changes — pages added, pages removed, raw assets ingested, downloader scripts updated — multiple coordinator-only files must be kept in sync: `wiki/index.md` (directory tree counts and entry lists), `raw/index.md` (asset map), and `raw/download_arxiv_papers.py` (the reproducible download list). This fragment defines the canonical sync procedure, replacing five drifted inlined copies in `ingest.md`, `batch-ingest.md`, `enrich.md`, `synthesize.md`, and `enrichment-audit.md` (where the orderings, sub-step counts, and included files all diverged).
+
+This fragment **does not** include log appends (`wiki/log.md` is its own concern, kept separate so the log is appended exactly once per workflow run, not once per index sync) and **does not** include MOC updates (those live in [`moc-update.md`](moc-update.md), kept separate so the moc-update logic is invoked exactly once per affected MOC, not once per index sync).
+
+## When to run
+
+- After any ingest (single or batch) once the source pages exist.
+- After any enrich pass that adds, removes, or restructures pages.
+- After any synthesize pass that creates new analysis pages.
+- After any enrichment-audit Phase 4 consolidation.
+- Any time a page count changes or a raw asset is added/removed/renamed.
+
+## Procedure
+
+1. **Update `wiki/index.md`'s directory tree.** Get the authoritative current counts from the filesystem (`Glob wiki/sources/**/*.md`, `Glob wiki/entities/*.md`, `Glob wiki/mocs/*.md`, `Glob wiki/analyses/*.md`, `Glob wiki/concepts/*.md`) and update each count in the tree to match. Do not rely on memory or arithmetic.
+
+2. **Update `wiki/index.md`'s entry lists.** Each section (Sources, Entities, MOCs, Analyses, Concepts) has a curated list of pages with one-line descriptions. Add the new pages in the position the section's ordering principle dictates (alphabetical, chronological, theme-grouped). Remove any deleted pages from the list. Do not append at the end by default.
+
+3. **Update `raw/index.md`** if the workflow added or removed raw assets. The "Canonical PDFs" table must reflect every PDF in `raw/pdf/arxiv-*.pdf`, the "LaTeX Sources" table must reflect every directory or tarball in `raw/latex/`, and the "Duplicate PDFs (Venue Copies)" section must reflect every venue-duplicate PDF actually present on disk. Verify each path with `Glob` before listing.
+
+4. **Update `raw/download_arxiv_papers.py`** if a new arXiv paper was added during the workflow. The new paper's ID must be in the downloader's list with the correct LaTeX storage mode (`archive` for tarball, `extract` for unpacked directory). The downloader must remain reproducible — running it from a clean clone should produce the on-disk state.
+
+5. **Append the corresponding row to `raw/checklist.md`** for each newly added arXiv paper using the [raw checklist row](raw-checklist-row.md) procedure. Skip this step if no arXiv assets were added.
+
+6. **Verify the bijection.** Every arXiv ID in `raw/index.md`'s "Canonical PDFs" table must have exactly one row in `raw/checklist.md`, and every row in `raw/checklist.md` must correspond to a PDF in `raw/pdf/`. Use the lint workflow's checklist sync check pattern if the workflow doing the sync is large.
+
+## Invariants
+
+- **Authoritative counts come from the filesystem**, not memory or arithmetic. Use `Glob` to count, and update `wiki/index.md` to match the count, not the other way around.
+- **Entry lists respect their section's ordering principle.** Appending at the end by default is wrong; the ordering principle (alphabetical, chronological, theme-grouped) is load-bearing.
+- **Path references must exist on disk** before being listed in `raw/index.md`. Phantom entries propagate and break lint passes.
+- **`raw/index.md` and `raw/checklist.md` are bijective for arXiv papers.** Every entry in one must have a corresponding entry in the other (excluding non-arXiv sources, which are intentionally excluded from the checklist).
+- **The downloader must remain reproducible.** A clean clone + downloader run must produce the on-disk state. Adding a paper to `raw/index.md` without adding it to the downloader is a bug, not a deferred task.
+- **This fragment does not append to `wiki/log.md`** (that is the calling workflow's responsibility, exactly once at the end) and **does not update MOCs** (that is [`moc-update.md`](moc-update.md), called once per affected MOC).
+- **This fragment does not run the [stale count sweep](stale-count-sweep.md).** The sweep is the calling workflow's responsibility after both the index update and any prose-count drift sites are visible.
+
+## After completion
+
+Return to the calling workflow and proceed with its next numbered step. This fragment is a subroutine — it has no terminal action of its own, and the calling workflow's remaining steps (MOC updates, stale count sweep, living analyses review, log entry, commit, report) are not optional just because the index and asset sync is done.
+
+## Used by
+
+- `workflows/ingest.md` (expected, PR 2b — Procedure steps 7, 9, 10, replacing the inlined directory-tree update + raw/index.md + downloader update)
+- `workflows/batch-ingest.md` (expected, PR 2b — Procedure step 4, the consolidation pass)
+- `workflows/enrich.md` (expected, PR 2b — Procedure steps 4, 5, 6, the index/raw/downloader sync sub-steps)
+- `workflows/synthesize.md` (expected, PR 2b — Procedure step 5, "Update `wiki/index.md` and any relevant MOCs")
+- `workflows/enrichment-audit.md` (expected, PR 2b — Phase 4 step 1, "Update `wiki/index.md` with new or changed page counts and entries")

--- a/workflows/_shared/procedures/verify-frontmatter-completeness.md
+++ b/workflows/_shared/procedures/verify-frontmatter-completeness.md
@@ -1,0 +1,53 @@
+# Verify Frontmatter Completeness
+
+## Purpose
+
+Wiki page frontmatter is the source of truth for type, title, provenance, and indexing. Drift in frontmatter (missing fields, wrong `type:` values, stale `latex_source:` paths) propagates into indexes and breaks plugin compatibility weeks later. This fragment defines the **canonical frontmatter schema by page type** and the per-context completeness check, replacing the four drifted inlined copies in `ingest.md`, `review.md`, `plugin-audit.md`, and `verification.md` (where the field set differed in every copy: ingest listed 9 fields, review listed 5, plugin-audit checked only `title:`, verification checked 2).
+
+## When to run
+
+- During an ingest, when creating a new source page (full schema for the page's type).
+- During a review pass, when spot-checking a sample of pages (universal-minimum check + per-type extensions).
+- During a plugin-audit pass (universal-minimum check; the plugin-specific extensions are tracked elsewhere).
+- During a verification pass on subagent-produced pages (full schema for the page's type — subagents commonly drop fields).
+
+## Canonical schema
+
+The canonical frontmatter schema by page type lives in [`../rules/frontmatter-schema.md`](../rules/frontmatter-schema.md). That rule is the single source of truth — this procedure references it and never restates the schema inline. Load-bearing summary for in-procedure decisions:
+
+- **Universal minimum** (every page): `type:`, `title:`, `created:`.
+- **Source pages** add: `source_file:`, `latex_source:` (if on disk), `author:`, `date_published:`, `date_ingested:`, `tags:`, conditionally `venue_pdfs:`.
+- **Entity pages** add: `aliases:`, `tags:`, `updated:`.
+- **Entity-partial pages** add: `parent:`, `partial:`.
+- **Other types** require only the universal minimum.
+
+For the full per-type schema, the recognized `type:` enumeration, and the field-by-field rationale, open the rule fragment.
+
+## Procedure
+
+1. **Determine the page's `type:`.** This selects which schema applies. Pages without a `type:` field are an immediate fail — flag and stop.
+2. **Verify the universal-minimum fields are present and well-formed.** `type`, `title`, `created`. Empty values count as missing.
+3. **Verify the per-type extensions** from the schema above. For source pages, all 8 fields plus the conditional `venue_pdfs:`. For entities, all 4 plus partial conventions if applicable. For concept/MOC/analysis/overview, the universal minimum is sufficient unless the workflow says otherwise.
+4. **Verify file path references resolve.** Every `source_file:`, `latex_source:`, `venue_pdfs:` path must exist on disk. Use `Glob` to confirm; never trust the frontmatter alone. Phantom paths are the most common drift class for source pages.
+5. **Verify `type:` matches the page's directory.** Source pages in `wiki/sources/`, entities in `wiki/entities/`, concepts in `wiki/concepts/`, MOCs in `wiki/mocs/`, analyses in `wiki/analyses/`. Mismatches indicate the page was created in the wrong place or its `type:` was set wrong.
+6. **Flag findings, do not silently fix during a review pass.** During an ingest where the page is newly created, fix in place. During a review/audit, surface the issue back to the workflow's findings list so the pattern is visible.
+
+## Invariants
+
+- The universal minimum (`type`, `title`, `created`) is non-negotiable for every wiki page. No exceptions.
+- `type:` values must come from the canonical enumeration. Custom or freeform `type:` values are caught by `workflows/schema-self-audit.md`.
+- File path references in frontmatter must exist on disk. Phantom `source_file:`, `latex_source:`, or `venue_pdfs:` entries are bugs, not documentation.
+- The conditional `venue_pdfs:` is only listed when the venue PDF is in `raw/pdf/`. Listing it before the file is downloaded creates a phantom that propagates into `raw/index.md` and breaks lint passes weeks later.
+- During a review/audit pass, this procedure flags findings rather than silently fixing them. Silent fixes hide drift patterns.
+- During an ingest, this procedure fixes in place because the page is being authored from scratch.
+
+## After completion
+
+Return to the calling workflow and proceed with its next numbered step. This fragment is a subroutine — it has no terminal action of its own, and the calling workflow's remaining steps (further checks, fixes, log entry, report) are not optional just because the frontmatter check is done.
+
+## Used by
+
+- `workflows/ingest.md` (expected, PR 2b — Procedure step 4, "Create a source summary page")
+- `workflows/review.md` (expected, PR 2b — Procedure step 2, "Spot-check that all pages have required frontmatter fields")
+- `workflows/plugin-audit.md` (expected, PR 2b — Procedure step 2, Pandoc compliance check; the universal-minimum check covers the `title:` requirement)
+- `workflows/verification.md` (expected, PR 2b — Procedure step 2, "Confirm frontmatter is complete and consistent")

--- a/workflows/_shared/rules/frontmatter-schema.md
+++ b/workflows/_shared/rules/frontmatter-schema.md
@@ -1,0 +1,65 @@
+# Rule: Frontmatter Schema
+
+## Statement
+
+Every wiki page MUST have frontmatter conforming to the canonical schema for its `type:`. Pages without a recognized `type:` are invisible to `workflows/schema-self-audit.md` and break plugin compatibility.
+
+## Schema
+
+### Universal minimum (every wiki page)
+
+- `type:` — one of `source`, `entity`, `entity-partial`, `concept`, `moc`, `analysis`, `overview`, `workflow-doc`. No freeform values.
+- `title:` — human-readable title. The Pandoc plugin requires this on every page.
+- `created:` — ISO date the page was first authored.
+
+### `type: source` (additionally)
+
+- `source_file:` — path to the canonical PDF, typically `raw/pdf/arxiv-XXXX.XXXXX.pdf`.
+- `latex_source:` — path to the LaTeX source if available. Use `raw/latex/arxiv-XXXX.XXXXX/` (with trailing slash) for `extract`-mode papers, or `raw/latex/arxiv-XXXX.XXXXX.tar.gz` for `archive`-mode papers. Omit cleanly if no LaTeX is on disk; never list a phantom path.
+- `author:` — paper author list.
+- `date_published:` — paper publication date.
+- `date_ingested:` — date the source was added to the wiki.
+- `tags:` — bracketed list for cross-referencing.
+- *(conditional)* `venue_pdfs:` — only if venue-duplicate PDFs are actually present in `raw/pdf/`. Verify each path with `Glob` before writing the frontmatter. Phantom `venue_pdfs:` entries propagate into `raw/index.md` and break lint passes weeks later.
+
+### `type: entity` (additionally)
+
+- `aliases:` — bracketed list of alternate names (institutions often have several).
+- `tags:` — bracketed list.
+- `updated:` — date of the most recent edit.
+
+When the entity uses transcluded partials (`timeline.md`, `researchers.md`), see `workflows/_shared/procedures/entity-partials.md` for the partial-structure conventions.
+
+### `type: entity-partial` (additionally)
+
+- `parent:` — slug of the parent entity (e.g. `amazon` for `wiki/entities/amazon/timeline.md`).
+- `partial:` — one of `timeline`, `researchers`. Add new partial types here as they are introduced.
+
+### `type: concept | moc | analysis | overview | workflow-doc`
+
+Require only the universal minimum unless an individual workflow's documentation demands more.
+
+## Rationale
+
+The schema-self-audit workflow uses `type:` to inventory pages. Missing or freeform `type:` values create invisible drift — the audit reports clean while pages are missing from the inventory.
+
+The Pandoc plugin requires `title:` on every page; pages without it fail to render in the published view, and the failure surface is the entire publish pipeline rather than a single page.
+
+Source pages without `source_file:` or `latex_source:` lose their connection to the underlying paper, breaking the wiki's source-of-truth invariant. Future ingests cannot cite back to the canonical asset, and `raw/index.md` ↔ source-page bijection breaks.
+
+Phantom file path entries in `source_file:`, `latex_source:`, or `venue_pdfs:` propagate into `raw/index.md` through the ingest workflow and break lint passes weeks after the original ingest. The "verify with Glob before writing" rule has been enforced multiple times after past breakage.
+
+## How violations are caught
+
+- `workflows/_shared/procedures/verify-frontmatter-completeness.md` — the per-page check, run during ingest, review, plugin-audit, and verification passes.
+- `workflows/schema-self-audit.md` — the vault-wide audit that inventories pages by `type:` and flags inconsistencies.
+- `workflows/lint.md` Redundancy & Dead-Reference Audit, section A — phantom path detection in frontmatter.
+
+## Used by
+
+- `workflows/_shared/procedures/verify-frontmatter-completeness.md` — canonical schema source for the per-page check
+- `workflows/_shared/procedures/raw-checklist-row.md` — the raw-checklist row format depends on `source_file:` and `latex_source:` field consistency
+- `workflows/schema-self-audit.md` (expected, PR 2b)
+- `workflows/lint.md` (expected, PR 2b)
+- `workflows/ingest.md`, `workflows/batch-ingest.md` (expected, PR 2b — page creation must conform)
+- `workflows/review.md`, `workflows/plugin-audit.md`, `workflows/verification.md` (expected, PR 2b — verification consumers)

--- a/workflows/_shared/rules/log-immutability.md
+++ b/workflows/_shared/rules/log-immutability.md
@@ -1,0 +1,35 @@
+# Rule: Log Immutability
+
+## Statement
+
+Entries in `wiki/log.md` are point-in-time records. They MUST NOT be backdated, rewritten, deleted, or updated to reflect later state. Counts inside log entries are correct-as-of the entry's date by definition; the [stale count sweep](../procedures/stale-count-sweep.md) explicitly excludes `wiki/log.md` from its updates.
+
+## What this means in practice
+
+- **Append-only.** New log entries always append to the end of the file with a current ISO date. Past entries are never reordered.
+- **No retroactive corrections.** If an old log entry says "wiki covers 25 papers" on a date when that was true, leave it alone even if the current count is 50. The entry is a historical claim about that date, not a claim about the present.
+- **No "the count drifted, let me fix the old entry" temptations.** This is the most common impulse to violate this rule. The count in a log entry is what was true *then*. The current count lives in `wiki/index.md`, the README badges, and the post-state of the next log entry — not in the past.
+- **No deletions, even of "wrong" entries.** If a log entry is factually incorrect about the work it describes, append a correction entry referencing the original; do not edit the original.
+- **No reformatting bulk passes.** Even cosmetic changes to old entries (markdown style, link formatting) are forbidden because they pollute the audit trail and obscure when the entry was actually written.
+
+## Rationale
+
+`wiki/log.md` is the audit trail for every workflow run. Its value depends entirely on the entries being honest snapshots of the moment they were written. Any backdating — even well-intentioned cleanup — destroys that value.
+
+Concretely: if a stale-count sweep updated past log entries to reflect the current count, the audit trail would no longer answer the question "what did the wiki look like on date X?". Instead it would always reflect the current state, making it useless for debugging when a regression was introduced or for understanding the wiki's history.
+
+This rule has been enforced multiple times after near-misses where bulk-update passes (count sweeps, slug renames, terminology normalizations) almost edited log.md. The [stale count sweep](../procedures/stale-count-sweep.md) and the [bulk source-page rename](../procedures/bulk-source-rename.md) both explicitly carve out `wiki/log.md` as off-limits.
+
+## How violations are caught
+
+- `workflows/_shared/procedures/stale-count-sweep.md` Invariants — explicit `wiki/log.md` exclusion in the sweep procedure.
+- `workflows/_shared/procedures/bulk-source-rename.md` — the sed-rewrite pattern excludes `wiki/log.md` by scoping to `wiki/sources/` and `raw/`, not the vault root.
+- `workflows/lint.md` Redundancy & Dead-Reference Audit — would surface log-entry rewrites as anomalies in the wiki's git history if a violation slipped through.
+- Manual: `git log -p wiki/log.md` should show only appends. Any modification to a previously-appended line is a violation worth investigating.
+
+## Used by
+
+- `workflows/_shared/procedures/stale-count-sweep.md` (canonical exclusion)
+- `workflows/_shared/procedures/bulk-source-rename.md` (canonical exclusion)
+- `workflows/CONVENTIONS.md` Meta-rules (this rule is also stated as a meta-rule there; the rule fragment is the canonical long form)
+- `workflows/ingest.md`, `workflows/batch-ingest.md`, `workflows/lint.md`, `workflows/review.md`, `workflows/enrich.md`, `workflows/synthesize.md`, `workflows/gap-analysis.md`, `workflows/enrichment-audit.md` (expected, PR 2b — every workflow that appends to log.md must respect this rule)

--- a/workflows/_shared/rules/path-discipline.md
+++ b/workflows/_shared/rules/path-discipline.md
@@ -1,0 +1,54 @@
+# Rule: Path Discipline
+
+## Statement
+
+Every file path written into the wiki — frontmatter values, body wiki-links, `raw/index.md` and `raw/checklist.md` entries, MOC reading-path links — MUST point to a file that actually exists on disk at the moment of writing. Phantom paths are never acceptable, even temporarily.
+
+Additionally, the canonical local-path prefixes are `raw/pdf/` and `raw/latex/`. The `reference/pdf/` and `reference/latex/` prefixes are stale historical paths from a pre-move vault layout and must never be reintroduced.
+
+## The two sub-rules
+
+### Sub-rule 1: No phantom paths
+
+Before writing any file path into the wiki, verify the path exists with `Glob` (or equivalent). This applies to:
+
+- Frontmatter `source_file:`, `latex_source:`, `venue_pdfs:`.
+- Body wiki-links of the form `[[raw/pdf/...]]`, `[[raw/latex/...]]`.
+- Rows in `raw/index.md`'s asset tables.
+- Rows in `raw/checklist.md`.
+- Cross-references in MOCs and analyses.
+
+The "I will download it next" reasoning is not acceptable. The file must be on disk before its path is written. If a path is needed before the file exists, the workflow must download the file first.
+
+### Sub-rule 2: Canonical prefixes only
+
+The only acceptable local-path prefixes for raw assets are:
+
+- `raw/pdf/arxiv-XXXX.XXXXX.pdf` for canonical PDFs.
+- `raw/pdf/<venue>-arxiv-XXXX.XXXXX.pdf` for venue-duplicate PDFs.
+- `raw/latex/arxiv-XXXX.XXXXX/` (with trailing slash) for `extract`-mode LaTeX directories.
+- `raw/latex/arxiv-XXXX.XXXXX.tar.gz` for `archive`-mode LaTeX tarballs.
+
+`reference/pdf/...` and `reference/latex/...` are stale. They predate a directory move and have caused drift in the past. The lint workflow's checklist sync check greps `raw/checklist.md` for these prefixes and requires zero matches.
+
+## Rationale
+
+Phantom paths propagate. A phantom `venue_pdfs:` entry in a source page's frontmatter is copied into `raw/index.md` by the next ingest, listed in `raw/checklist.md` by the next batch update, and cited in a MOC by the next enrich pass. By the time the lint workflow catches the phantom (weeks later), it lives in 4–5 files and the cleanup requires the bulk-rewrite procedure.
+
+The "verify with `Glob` first" rule is cheap (one tool call) and catches the regression at the cheapest possible point: before the path is ever written. Every past phantom-path bug would have been prevented by enforcing this rule at write time.
+
+The `reference/` prefix predates a directory reorganization that moved everything under `raw/`. The old prefix lingers in the agent's training data and is reintroduced during ingests by agents that haven't been told the move happened. Listing the deprecated prefix here is the durable defense.
+
+## How violations are caught
+
+- `workflows/_shared/procedures/raw-checklist-row.md` — invariants forbid `reference/pdf/...` and `reference/latex/...`.
+- `workflows/lint.md` Redundancy & Dead-Reference Audit, section A — phantom raw asset detection (greps frontmatter and body links against the actual `raw/pdf/` and `raw/latex/` listings).
+- `workflows/lint.md` checklist sync check — greps `raw/checklist.md` for `reference/pdf/` and `reference/latex/`, requires zero matches.
+
+## Used by
+
+- `workflows/_shared/procedures/raw-checklist-row.md` (canonical row format that enforces the prefixes)
+- `workflows/_shared/procedures/verify-frontmatter-completeness.md` (per-page check that validates path resolution)
+- `workflows/_shared/rules/frontmatter-schema.md` (the conditional `venue_pdfs:` clause references this rule)
+- `workflows/ingest.md`, `workflows/batch-ingest.md` (expected, PR 2b — applies to every page-creation step)
+- `workflows/lint.md` (expected, PR 2b — applies to phantom detection sub-pass)

--- a/workflows/_shared/rules/shared-file-off-limits.md
+++ b/workflows/_shared/rules/shared-file-off-limits.md
@@ -1,0 +1,64 @@
+# Rule: Coordinator-Only Files
+
+## Statement
+
+A specific set of files is **coordinator-only**: subagents launched in parallel from a workflow MUST NOT edit them. The coordinator (the human user or the orchestrator agent running the workflow) is the only writer for these files. Subagents that need to surface changes to a coordinator-only file MUST report the need rather than editing the file themselves.
+
+## The canonical enumeration
+
+The complete list of coordinator-only files. Subagents must treat all of these as read-only:
+
+- `wiki/index.md`
+- `wiki/log.md`
+- `wiki/overview-state-of-field.md`
+- All MOCs under `wiki/mocs/*.md`
+- All living analyses under `wiki/analyses/*.md`
+- `raw/index.md`
+- `raw/checklist.md`
+- `raw/download_arxiv_papers.py`
+- `AGENTS.md`
+- `README.md`
+- Any fragment under `workflows/_shared/`
+- Any workflow file under `workflows/*.md`
+
+## Why this enumeration is canonical
+
+Earlier inlined off-limits lists in `batch-ingest.md`, `verification.md`, `moc-gap-analysis.md`, and `enrichment-audit.md` each enumerated a different subset. The drift was real and produced bugs:
+
+- `enrichment-audit.md` Phase 3 omitted `raw/index.md`, allowing parallel agents to race-edit it.
+- `moc-gap-analysis.md` step 11 omitted both `raw/index.md` and `AGENTS.md`.
+- `batch-ingest.md` was the only workflow that explicitly forbade `AGENTS.md`.
+- `verification.md` named "shared files" generically without an enumeration at all.
+
+This rule fragment is the single source of truth. Workflow-level enumerations are forbidden; workflows reference this rule instead.
+
+## Rationale
+
+Coordinator-only files have one or more of these properties:
+
+1. **Aggregate state** (`wiki/index.md`, `raw/index.md`, `raw/checklist.md`) — they summarize the entire vault, so concurrent edits race-condition into corruption.
+2. **Append-only audit trails** (`wiki/log.md`) — see [log-immutability.md](log-immutability.md). Subagents writing to log.md break the chronological ordering invariant.
+3. **Cross-cutting synthesis** (`wiki/overview-state-of-field.md`, all `wiki/analyses/*.md`, all `wiki/mocs/*.md`) — they reflect editorial judgments that span the whole vault. A subagent working on a single page lacks the context to update them correctly.
+4. **Reproducibility surfaces** (`raw/download_arxiv_papers.py`) — must remain runnable from a clean clone. Subagent edits without the full asset list can break the downloader.
+5. **Process documentation** (`AGENTS.md`, `workflows/*.md`, `workflows/_shared/**`) — they shape future workflow runs and deserve PR review even when the author is the same agent.
+6. **Public surfaces** (`README.md`) — visible to external readers and curated separately.
+
+The cost of forbidding subagent edits to these files is small (the coordinator consolidates after the parallel phase). The cost of allowing them is high (race conditions, lost work, audit trail corruption).
+
+## How violations are caught
+
+- `workflows/_shared/procedures/parallel-subagent-protocol.md` — enforces the rule at subagent dispatch time. Subagent prompts MUST include the enumeration and the "report, do not edit" instruction.
+- `workflows/_shared/procedures/spot-check-agent-output.md` — would surface unexpected edits to coordinator-only files in the post-phase sample.
+- `workflows/verification.md` (expected, PR 2b) — full verification pass would catch any edits to coordinator-only files in the parallel-phase output.
+- Manual: `git diff --stat` on the parallel-phase output should show zero changes to any file in this enumeration.
+
+## How to extend the enumeration
+
+When a new file becomes coordinator-only — typically because a workflow change makes it aggregate, append-only, or cross-cutting — add it here. Do not add it to individual workflows; that path is what produced the original drift.
+
+## Used by
+
+- `workflows/_shared/procedures/parallel-subagent-protocol.md` (canonical enforcement point — every subagent dispatch consumes this enumeration)
+- `workflows/_shared/procedures/spot-check-agent-output.md` (post-phase verification reference)
+- `workflows/_shared/procedures/commit-and-push.md` (the "do not touch" bucket overlaps with this enumeration)
+- `workflows/batch-ingest.md`, `workflows/verification.md`, `workflows/moc-gap-analysis.md`, `workflows/enrichment-audit.md`, `workflows/plugin-audit.md` (expected, PR 2b — replacing each workflow's drifted inline enumeration)

--- a/workflows/_shared/rules/slug-disambiguation.md
+++ b/workflows/_shared/rules/slug-disambiguation.md
@@ -1,0 +1,42 @@
+# Rule: Slug Disambiguation
+
+## Statement
+
+Source page slugs MUST disambiguate by default. Before creating a new source page, check whether the leading hyphen-token of the candidate slug already exists in the same `wiki/sources/**/` directory. If it does, use the hybrid form `<technique>-<institution>-<distinguisher>.md` so collisions never accumulate.
+
+## Hybrid form
+
+`<technique>-<institution>-<distinguisher>.md`
+
+Examples (from past KVComm collisions that prompted this rule):
+
+- `kvcomm-kth-selective.md` — KVComm technique, KTH lead, "selective" as the distinguishing approach.
+- `kvcomm-duke-online-reuse.md` — KVComm technique, Duke lead, "online reuse" as the distinguishing approach.
+- `coconut-meta-reasoning.md` — Coconut technique, Meta (FAIR) lead, "reasoning" as the use-case distinguisher.
+
+## Procedure (during ingest)
+
+1. **Glob** `wiki/sources/**/*.md` and inspect the leading hyphen-token of every existing slug in the target subdirectory.
+2. If your candidate slug's leading token (e.g. `kvcomm-`, `coconut-`) is already present in another file from a different paper, switch to the hybrid form before creating the new file.
+3. The institution component should match the lead author's primary affiliation. If the lead has shared institutional credit, pick the institution most closely associated with the technique's prior work.
+4. The distinguisher should be a short phrase (1–2 words) that captures the paper's most distinctive contribution relative to the colliding slug — its mechanism, its application, its dataset, etc.
+
+## Rationale
+
+When two source pages share a leading filename token, readers cannot disambiguate them without opening both files. In a vault with thousands of cross-references, this regularly produces wrong-page navigation: clicking `[[kvcomm-...]]` lands on the alphabetically-first match rather than the intended paper.
+
+The hybrid form solves this at file creation time, which is cheaper than retroactive disambiguation via the [bulk source-page rename](../procedures/bulk-source-rename.md) procedure (which requires updating every backlink in the vault). The KVComm collision in early 2026 forced two retroactive renames; codifying the rule prevents the third.
+
+The "in the same `wiki/sources/**/` directory" qualifier matters because cross-directory collisions are rarer (the directory itself usually disambiguates) and adding institution + distinguisher to every slug would inflate filenames unnecessarily. The trigger is a same-directory leading-token collision specifically.
+
+## How violations are caught
+
+- `workflows/lint.md` Redundancy & Dead-Reference Audit, section C — slug-collision detection. Groups basenames by their first hyphenated token within each `wiki/sources/**/` directory and flags clusters of size ≥ 2 from different papers.
+- The fix is `workflows/_shared/procedures/bulk-source-rename.md` for retroactive disambiguation.
+
+## Used by
+
+- `workflows/ingest.md` (expected, PR 2b — Procedure step 3, "Pick a slug")
+- `workflows/batch-ingest.md` (expected, PR 2b — applies to every paper in the batch)
+- `workflows/lint.md` (expected, PR 2b — Redundancy & Dead-Reference Audit, section C)
+- `workflows/_shared/procedures/bulk-source-rename.md` — the retroactive fix when this rule was violated


### PR DESCRIPTION
Second slice of the workflows/ deduplication tracked in #7. **Fragments only** — no workflow files are modified. PR 2b will rewire the 8 affected workflows.

## Summary

- **8 new procedure fragments** under `workflows/_shared/procedures/`, each with the chaining-contract `## After completion` section.
- **5 new rule fragments** under `workflows/_shared/rules/`, each as a single source of truth for a load-bearing invariant.
- **1 new glossary** at `workflows/_shared/glossary.md` with 10 canonical terms (expands the 4-term seed in `CONVENTIONS.md`).
- **1 retrofit**: `entity-partials.md` gains its `## After completion` section. It was created on master by #10/#11/#12 before the chaining contract existed and was the only contract violation in `_shared/procedures/`.

## Single-source-of-truth discipline

Two procedure fragments deliberately do **not** restate content that lives canonically in a rule:

- `verify-frontmatter-completeness.md` references `rules/frontmatter-schema.md` rather than restating the per-type schema. The rule is the canonical source; the procedure focuses on the *check*.
- `parallel-subagent-protocol.md` references `rules/shared-file-off-limits.md` rather than re-enumerating coordinator-only files. The rule is the canonical source; the procedure focuses on the *dispatch contract*.

This is the single-source-of-truth invariant the whole `_shared/` tree exists to enforce.

## Drift reconciliation

Three procedure fragments and one rule fragment merged content from multiple drifted inline copies. The audit (in #7) measured the drift before extraction; this PR resolves it.

| Fragment | Sources | Drift evidence |
|---|---|---|
| `parallel-subagent-protocol.md` | `batch-ingest.md:75-93` + `verification.md:81-95` + `moc-gap-analysis.md:88-100` + `enrichment-audit.md:112-124` | The off-limits file enumeration differed in every copy. `enrichment-audit` omitted `raw/index.md`; `moc-gap-analysis` omitted both `raw/index.md` and `AGENTS.md`; `batch-ingest` was the only one explicitly forbidding `AGENTS.md`. |
| `verify-frontmatter-completeness.md` | `ingest.md:86` + `review.md:86-88` + `plugin-audit.md:72` + `verification.md:85` | The required field set differed in every copy: ingest listed 9 fields, review listed 5, plugin-audit checked only `title:`, verification checked 2. |
| `update-index-and-assets.md` | `ingest.md:96-108` + `batch-ingest.md:85-89` + `enrich.md:100-104` + `synthesize.md:101` + `enrichment-audit.md:127-130` | 5 consumers with 3+ different sub-step orderings. Some included log appends; some included MOC updates. The fragment explicitly excludes both (log = workflow's job exactly once at end; MOCs = `moc-update.md`, called once per affected MOC). |
| `commit-and-push.md` | `gap-analysis.md:201-226` (long form) + `ingest.md:113` (one-line pointer) | Not drifted in content; the long form was canonical and the one-line pointer was a gesture toward it. The fragment now is the canonical long form, and both consumers will reference it from PR 2b onward. |

## Fragment list

**Procedures (`workflows/_shared/procedures/`):**

- `bulk-source-rename.md`
- `commit-and-push.md`
- `entity-partials.md` (retrofit only — `## After completion` section added)
- `moc-update.md`
- `parallel-subagent-protocol.md`
- `raw-checklist-row.md`
- `spot-check-agent-output.md`
- `update-index-and-assets.md`
- `verify-frontmatter-completeness.md`

**Rules (`workflows/_shared/rules/`):**

- `frontmatter-schema.md`
- `log-immutability.md`
- `path-discipline.md`
- `shared-file-off-limits.md`
- `slug-disambiguation.md`

**Glossary (`workflows/_shared/`):**

- `glossary.md` — 10 terms with drift variants and canonical names. Replaces the 4-term seed in `CONVENTIONS.md` (PR 2b will remove the seed once workflows reference this fragment directly).

## What's not in this PR

- **No workflow files are modified.** PR 2b is the wiring pass: ~25 call sites across 8 workflows (`ingest`, `gap-analysis`, `batch-ingest`, `enrichment-audit`, `moc-gap-analysis`, `verification`, `enrich`, `review`).
- **No checklist fragments yet.** `_shared/checklists/base.md`, `ingest-additions.md`, `audit-additions.md` land in PR 2b alongside the workflow rewiring.
- **Used by footers still mark consumers as `(expected, PR 2b)`.** PR 2b will drop those markers as it wires up the workflows.

## Test plan

- [ ] Render `workflows/_shared/glossary.md` and confirm the 10 terms include the 4 from the `CONVENTIONS.md` seed plus 6 new ones (`MOC` vs `reading path` distinction, `thin pages`, `phantom assets`, `stale claim`, `orphan page`, `red link`).
- [ ] Open each of the 8 new procedure fragments and confirm every one ends with `## After completion` above `## Used by`, per the chaining contract.
- [ ] Open `workflows/_shared/procedures/entity-partials.md` and confirm the retrofit added `## After completion` (it now exists where it didn't before).
- [ ] Open `workflows/_shared/procedures/verify-frontmatter-completeness.md` and confirm the schema is referenced from `../rules/frontmatter-schema.md` rather than restated inline.
- [ ] Open `workflows/_shared/procedures/parallel-subagent-protocol.md` and confirm the off-limits enumeration is referenced from `../rules/shared-file-off-limits.md` rather than restated inline.
- [ ] Spot-check the drift reconciliation table above against any one of the listed source line ranges to confirm the merged fragment captures the rule delta.
- [ ] Confirm no workflow files (`workflows/*.md` other than fragments) are in the PR diff. PR 2a is fragments-only.

Refs #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
