### PR TITLE
refactor(workflows): wire source-partials into ingest + lint (PR 3)

### DIFF
--- a/workflows/_shared/checklists/ingest-additions.md
+++ b/workflows/_shared/checklists/ingest-additions.md
@@ -12,7 +12,7 @@ The completion items specific to workflows that add new source pages to the wiki
 
 ## The ingest additions
 
-- [ ] **The source page exists in the correct `wiki/sources/` subdirectory** at full depth standard. Frontmatter passes [`../procedures/verify-frontmatter-completeness.md`](../procedures/verify-frontmatter-completeness.md). The page has a `## Source Materials` footer pointing to existing files.
+- [ ] **The source page exists in the correct `wiki/sources/` subdirectory** at full depth standard, with a `## One-liner` heading + `![[<slug>/one-liner]]` embed below the H1, and a matching `wiki/sources/<category>/<slug>/one-liner.md` partial file with `type: source-partial`, `parent: <slug>`, `partial: one-liner` frontmatter per [`../procedures/source-partials.md`](../procedures/source-partials.md). Frontmatter passes [`../procedures/verify-frontmatter-completeness.md`](../procedures/verify-frontmatter-completeness.md). The page has a `## Source Materials` footer pointing to existing files.
 - [ ] **All relevant entity and concept pages were updated or created.** Entity updates use the partial structure defined in [`../procedures/entity-partials.md`](../procedures/entity-partials.md): edits to `wiki/entities/<slug>/timeline.md` and (if applicable) `wiki/entities/<slug>/researchers.md`, never to MOC or analysis transclusion sites.
 - [ ] **Relevant MOCs include the new reading-path entry**, inserted in the position the MOC's ordering principle dictates (not appended at the end). Per [`../procedures/moc-update.md`](../procedures/moc-update.md).
 - [ ] **`wiki/index.md` and `raw/index.md` and `raw/download_arxiv_papers.py` are in sync** with the new source. Per [`../procedures/update-index-and-assets.md`](../procedures/update-index-and-assets.md).

--- a/workflows/audit/lint.md
+++ b/workflows/audit/lint.md
@@ -147,6 +147,18 @@ Two MOCs are redundant when one defers to the other for its primary content. Two
 2. For any MOC whose body section is duplicated in another MOC, propose collapsing it to the unique scaffolding (cross-cutting concepts, key entities, theoretical foundations) and adding a one-line pointer to the canonical source.
 3. For concept-page overlap, prefer keeping the synthesis page and folding the duplicate into a section anchor.
 
+### E. Source-partial integrity
+
+Every source page under `wiki/sources/` must follow the partial structure defined in `workflows/_shared/procedures/source-partials.md`: a `## One-liner` heading + `![[<slug>/one-liner]]` embed in the shell, plus a matching `<slug>/one-liner.md` partial file with `type: source-partial` frontmatter. Drift here means MOCs that transclude the partial silently render an empty embed.
+
+1. `Glob wiki/sources/**/*.md` excluding `*/one-liner.md` → list of source shells.
+2. For each shell, confirm:
+   - The shell contains the line `![[<slug>/one-liner]]` (where `<slug>` is the shell's basename minus `.md`).
+   - The file `wiki/sources/<category>/<slug>/one-liner.md` exists.
+   - The partial's frontmatter has `type: source-partial`, `parent: <slug>` matching the shell's basename, and `partial: one-liner`.
+3. `Glob wiki/sources/**/one-liner.md` → list of partial files. Reverse-check: every partial has a parent shell at `wiki/sources/<category>/<parent>.md`, and the parent shell embeds it. Orphan partials and partials whose parent has been deleted are both bugs.
+4. `Grep -n '\!\[\[.*#One-liner\]\]' wiki/` → must return zero matches. The `![[<slug>#One-liner]]` section-anchor form is the legacy syntax superseded by `![[<slug>/one-liner]]`; any remaining instances should be migrated to the file-partial form. (Plain wiki-links of the form `[[<slug>#One-liner]]` *without* the leading `!` are still acceptable — they navigate to the heading anchor rather than embedding content.)
+
 ## Completion Checklist
 - All items in [`../_shared/checklists/base.md`](../_shared/checklists/base.md) hold.
 - All items in [`../_shared/checklists/audit-additions.md`](../_shared/checklists/audit-additions.md) hold.

--- a/workflows/create/ingest.md
+++ b/workflows/create/ingest.md
@@ -82,9 +82,10 @@ Do not use this workflow when the task is only to answer a question, run a lint 
 1. Read the source file in `raw/`.
 2. Discuss key takeaways with the user. Ask what to emphasize if unclear.
 3. **Pick a slug that disambiguates by default.** Before creating the file, `Glob wiki/sources/**/*.md` and check whether the leading hyphen-token of your candidate slug already exists (e.g., another `kvcomm-*` or `coconut-*`). If it does, use the hybrid form `<technique>-<institution>-<distinguisher>.md` so collisions never accumulate.
-4. Create a source page in the appropriate `wiki/sources/` subdirectory.
+4. Create a source page in the appropriate `wiki/sources/` subdirectory. Source pages use the **partial structure** defined in [`../_shared/procedures/source-partials.md`](../_shared/procedures/source-partials.md): a narrative shell at `wiki/sources/<category>/<slug>.md` plus a one-liner partial at `wiki/sources/<category>/<slug>/one-liner.md`, embedded into the shell via `![[<slug>/one-liner]]`.
    - Author the frontmatter, then run [verify frontmatter completeness](../_shared/procedures/verify-frontmatter-completeness.md) in full and return here before continuing. The fragment is the canonical schema; per-type field lists live there, not here.
    - **Conditional `venue_pdfs:`**: only list a venue PDF when the file is actually present in `raw/pdf/` — verify each path with `Glob` before writing the frontmatter. Phantom `venue_pdfs:` entries propagate into `raw/index.md` and break lint passes weeks later. (This invariant is repeated inline because losing it in delegation has bitten previous ingests; the fragment also enforces it.)
+   - Add a `## One-liner` heading immediately below the H1, with `![[<slug>/one-liner]]` underneath. Create the partial file at `wiki/sources/<category>/<slug>/one-liner.md` with `type: source-partial`, `parent: <slug>`, `partial: one-liner` frontmatter and a 1–3 sentence body following the shape **bold name + mechanism + key constraint or headline result**. See [`../_shared/procedures/source-partials.md`](../_shared/procedures/source-partials.md) for the full convention and examples.
    - Add a `## Source Materials` footer linking to the PDF and LaTeX source. Both paths must already exist on disk.
    - Fill in section-specific detail per the depth standard.
 5. For each significant entity or concept mentioned:


### PR DESCRIPTION
## Summary

Operationalizes the source-partials convention introduced in [#15](https://github.com/CompleteTech-LLC-AI-Research/beyond-the-token-bottleneck/pull/15) by teaching the ingest workflow to create one-liner partials by default and the lint workflow to detect drift. Without these, the next ingest would silently revert to inline one-liners and the convention would decay back into duplication.

This is the **operationalization** PR in the source-partials sequence. With it merged, the convention is enforceable: new ingests follow the checklist, and `workflows/lint.md` catches any drift in either direction.

## What changed

**[`workflows/ingest.md`](workflows/ingest.md) step 4** now documents the source-partial structure, mirroring the wording the entity-partials team added to step 6 in [#12](https://github.com/CompleteTech-LLC-AI-Research/beyond-the-token-bottleneck/pull/12). New ingests must:
- Create the shell with full frontmatter (unchanged).
- Add a `## One-liner` heading immediately below the H1 with `![[<slug>/one-liner]]` underneath.
- Create the partial file at `wiki/sources/<category>/<slug>/one-liner.md` with `type: source-partial`, `parent: <slug>`, `partial: one-liner` frontmatter and a 1–3 sentence body.

The procedure file (`workflows/_shared/procedures/source-partials.md`, added in #15) is linked for the full convention and writing guidance. Completion checklist updated to require the partial file by name.

**[`workflows/lint.md`](workflows/lint.md)** gains a new **Class E (Source-partial integrity)** in the Redundancy & Dead-Reference Audit, parallel to the existing Class A–D structure:

1. Forward check: every source shell embeds its partial (`![[<slug>/one-liner]]` present).
2. Forward check: every source shell's partial file exists.
3. Forward check: every partial's frontmatter has the correct `type`, `parent`, `partial` fields.
4. Reverse check: no orphan partial files (every partial has a parent shell that embeds it).
5. Legacy-syntax sweep: `Grep '\!\[\[.*#One-liner\]\]'` must return zero matches — the section-anchor embed form is superseded by the file-partial form. (Plain `[[<slug>#One-liner]]` heading-links *without* the `!` are still acceptable.)

## Stacking

This PR is **stacked on [#16](https://github.com/CompleteTech-LLC-AI-Research/beyond-the-token-bottleneck/pull/16)** (its base is `refactor/mocs-atoms-pr2`, not `master`). The full sequence:

| PR | Base | Content |
| --- | --- | --- |
| [#15](https://github.com/CompleteTech-LLC-AI-Research/beyond-the-token-bottleneck/pull/15) | `master` | Source-partials infrastructure: 27 one-liner atoms + 8 transclusions + procedure |
| [#16](https://github.com/CompleteTech-LLC-AI-Research/beyond-the-token-bottleneck/pull/16) | `refactor/mocs-atoms-pr1` | Focused fixups: safety §6a renumber + latent-communication theory dedup |
| #17 (this PR) | `refactor/mocs-atoms-pr2` | Workflow wiring: ingest + lint |

Merge in order, or rebase the later PRs onto `master` after each lands.

## Why this is a separate PR

Workflow files (`workflows/*.md`) are governed by [`workflows/CONVENTIONS.md`](workflows/CONVENTIONS.md), which is updated via PR (not direct master commits). Bundling workflow changes with content changes would require either splitting the commits anyway or breaking the rule. Keeping #15/#16 as content-only and #17 as workflow-only respects the existing discipline.

## Test plan

- [x] `workflows/ingest.md` step 4 now references `workflows/_shared/procedures/source-partials.md` and prescribes the partial structure.
- [x] `workflows/ingest.md` completion checklist requires the partial file by name.
- [x] `workflows/lint.md` Class E exists with five concrete checks (3 forward, 1 reverse, 1 legacy-syntax sweep).
- [x] The legacy-syntax sweep (`Grep '\!\[\[.*#One-liner\]\]' wiki/`) returns zero matches against the current vault — confirmed during PR #15 verification.
- [ ] **For reviewer**: confirm the wording in `ingest.md` step 4 matches the style of the entity-partials wording in step 6.
- [ ] **For reviewer**: confirm Class E in `lint.md` is structured consistently with Classes A–D (each has a "what's the invariant" preamble + numbered concrete checks).
- [ ] **For reviewer**: spot-check that the next ingest run (whenever that happens) actually follows the new step 4 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)