### PR TITLE
refactor(workflows): PR 2b — wire fragments + checklist tier + drop CONVENTIONS seed

### DIFF
--- a/workflows/CONVENTIONS.md
+++ b/workflows/CONVENTIONS.md
@@ -29,22 +29,15 @@ Every workflow file MUST use the following heading order. Sections marked option
 
 Optional trailing sections (such as `## Notes for Future Refinement`) may appear after `## Related Workflows` but must not displace any of the required sections above.
 
-## Terminology glossary (seed)
+## Terminology
 
-Canonical names for concepts that have drifted across existing workflows. This seed will be expanded in PR 2's `_shared/glossary.md`.
-
-| Canonical term | Deprecated / drift variants | Notes |
-| --- | --- | --- |
-| living analyses | gap-tracking analysis pages; analysis pages in `wiki/analyses/` | The six+ files under `wiki/analyses/` that must be checked on every ingest. `gap-analysis.md` uses "gap-tracking analysis pages"; `ingest.md` uses "living analysis". Prefer "living analyses". |
-| source page | source summary page; source file page | A markdown page under `wiki/sources/**/` that summarizes a single paper. `ingest.md` mixes "source summary page" and "source page". Prefer "source page". |
-| reading path | reading path outline; MOC reading path | The ordered traversal baked into a MOC. `ingest.md` uses "reading path"; older drafts used "reading path outline". Prefer "reading path". |
-| coordinator-only files | shared files; off-limits for agents; do-not-touch files | Files that only the coordinator (human or orchestrator agent) may edit. Prefer "coordinator-only files"; avoid "shared" (ambiguous with `_shared/` fragments). |
+Canonical terms and drift variants are tracked in [`_shared/glossary.md`](_shared/glossary.md). New terms go in the glossary, not here. The lint and review workflows grep for the drift variants enumerated there and surface them as findings.
 
 ## Meta-rules
 
 - Never reference a file path without verifying it exists on disk. Phantom references propagate into indexes and break lint passes weeks later.
 - Log entries in `wiki/log.md` are point-in-time records — never backdate, never rewrite, never sweep counts inside them.
-- Workflow file changes go via feature branch + PR, never directly to `master` (see `ingest.md:123` and `gap-analysis.md` Phase 6).
+- Workflow file changes go via feature branch + PR, never directly to `master` (see [`_shared/procedures/commit-and-push.md`](_shared/procedures/commit-and-push.md) for the canonical procedure).
 - Mermaid node labels use `<br>` for line breaks, not `\n` (which renders literally in Obsidian).
 - Fragment links use relative paths from the workflow file's location (e.g. `_shared/procedures/stale-count-sweep.md`, not `/workflows/_shared/...`).
 

--- a/workflows/_shared/checklists/audit-additions.md
+++ b/workflows/_shared/checklists/audit-additions.md
@@ -1,0 +1,30 @@
+# Audit Completion Additions
+
+## Purpose
+
+The completion items specific to workflows that audit the wiki without (necessarily) creating new content: `lint.md`, `review.md`, `enrichment-audit.md`, `verification.md`, `schema-self-audit.md`, and `plugin-audit.md`. Compose with [`base.md`](base.md) — both must hold for an audit-class workflow to be considered complete.
+
+## When to use
+
+- At the end of any audit-class workflow run.
+- After applying audit-found fixes, to confirm the audit's findings list is fully resolved.
+
+## The audit additions
+
+- [ ] **Findings are grouped by class** (content vs structural for lint, depth vs link for enrichment-audit, factual vs overstatement vs missing-coverage for verification). Mixed-class findings hide patterns.
+- [ ] **Proposed fixes are specific and actionable** — file path + line number + exact change, not "the page needs work". A finding without a fix is a deferred TODO, not a finding.
+- [ ] **No silent fixes were applied during the audit pass.** Audit workflows flag findings; the user (or a follow-up workflow run) approves and applies. Silent fixes hide error patterns and prevent learning where drift clusters.
+- [ ] **Fixes were applied only after user approval**, in the priority order documented by the workflow (factual errors → overstatements → missing coverage → style for verification; high → medium → low for enrichment-audit).
+- [ ] **The escalation rule was honored** if the audit included a parallel-subagent phase. Per [`../procedures/spot-check-agent-output.md`](../procedures/spot-check-agent-output.md): 2+ issues across the spot-check sample → full verification pass before consolidation.
+- [ ] **The log entry mentions which class of finding fired**, not just "ran the audit". Future audit passes can grep the log to track which classes drift fastest.
+- [ ] **If the audit revealed terminology drift**, the canonical terms in [`../glossary.md`](../glossary.md) were applied (or the drift was added to the audit's findings list for the user to apply).
+- [ ] **No coordinator-only files were edited by review subagents** if any were dispatched. The protocol in [`../procedures/parallel-subagent-protocol.md`](../procedures/parallel-subagent-protocol.md) is non-negotiable for audit workflows that fan out to subagents (verification's read-only review agents are a special case but the rule still applies).
+
+## Used by
+
+- `workflows/lint.md`
+- `workflows/review.md`
+- `workflows/enrichment-audit.md`
+- `workflows/verification.md`
+- `workflows/schema-self-audit.md`
+- `workflows/plugin-audit.md`

--- a/workflows/_shared/checklists/base.md
+++ b/workflows/_shared/checklists/base.md
@@ -1,0 +1,37 @@
+# Base Completion Checklist
+
+## Purpose
+
+The universal post-conditions every workflow must satisfy before it is considered complete, regardless of which workflow ran. This fragment is the floor — domain-specific workflows compose their own checklist by starting from this base and adding their own items via [`ingest-additions.md`](ingest-additions.md), [`audit-additions.md`](audit-additions.md), or workflow-specific bullets.
+
+## When to use
+
+- Embed this checklist (by reference, not by copy) into the `## Completion Checklist` section of every workflow.
+- Run through each item before marking a workflow run as complete.
+- During a review pass, verify that each item below holds.
+
+## The base checklist
+
+- [ ] **No coordinator-only files were edited by subagents.** The canonical enumeration is in [`../rules/shared-file-off-limits.md`](../rules/shared-file-off-limits.md). If a parallel-subagent phase ran, `git diff --stat` on the parallel-phase output must show zero changes to any file in that enumeration.
+- [ ] **Every file path referenced in this run exists on disk.** Frontmatter `source_file:`, `latex_source:`, `venue_pdfs:`, body `[[wiki-links]]`, `[[raw/...|...]]` body links, and `Glob`/`Read` targets must all resolve. Phantom paths are caught by the lint workflow's Redundancy & Dead-Reference Audit; do not let this run be the one that introduces them. See [`../rules/path-discipline.md`](../rules/path-discipline.md).
+- [ ] **`wiki/log.md` has an entry for this run** (for any workflow that mutated state). The entry follows the existing log format and reflects what actually happened, not what was planned. Log entries are immutable point-in-time records — never backdate, never rewrite, never sweep counts inside them. See [`../rules/log-immutability.md`](../rules/log-immutability.md).
+- [ ] **If the page count changed, the [stale count sweep](../procedures/stale-count-sweep.md) was performed.** The sweep is a first-class regression class — it is not optional just because the workflow doing the count change is not `ingest`. Any workflow that adds, removes, renames, or reorganizes pages must run the sweep before marking complete.
+- [ ] **`wiki/index.md` reflects the current vault state.** Directory tree counts, entry lists, and ordering principles are all in sync with the filesystem. The authoritative counts come from `Glob`, not memory.
+- [ ] **The terminology in any new prose uses canonical terms** from [`../glossary.md`](../glossary.md). Drift variants ("gap-tracking analysis pages", "shared files", "stub pages", etc.) should not be introduced by this run.
+
+## Composition with workflow-specific items
+
+Workflows extend this checklist by adding their own items in their `## Completion Checklist` section. The composition pattern is:
+
+1. The workflow's checklist begins with a one-line reference: "All items in [`_shared/checklists/base.md`](_shared/checklists/base.md) hold."
+2. Followed by workflow-specific items (page created, MOC updated, analysis reviewed, audit findings reported, etc.).
+
+For ingest, batch-ingest, and gap-analysis, the workflow-specific items are pre-bundled in [`ingest-additions.md`](ingest-additions.md). For lint, review, enrichment-audit, and verification, they live in [`audit-additions.md`](audit-additions.md). Other workflows enumerate their items inline.
+
+## Why a base checklist exists
+
+Before this fragment, every workflow's `## Completion Checklist` re-listed the same universal items (log entry, no shared-file edits, count sync) with subtly different wording. The drift hid violations: a workflow that omitted the count-sync bullet trained agents to skip it. Centralizing the universal items here makes the floor visible and the omissions impossible.
+
+## Used by
+
+- Every workflow's `## Completion Checklist` section, by reference.

--- a/workflows/_shared/checklists/ingest-additions.md
+++ b/workflows/_shared/checklists/ingest-additions.md
@@ -1,0 +1,30 @@
+# Ingest Completion Additions
+
+## Purpose
+
+The completion items specific to workflows that add new source pages to the wiki: `ingest.md`, `batch-ingest.md`, and `gap-analysis.md` (Phase 3 onward). Compose with [`base.md`](base.md) — both must hold for an ingest-class workflow to be considered complete.
+
+## When to use
+
+- At the end of any single-paper or multi-paper ingest.
+- At the end of `gap-analysis.md` once the procured paper has been ingested.
+- During a review of a recent ingest, to verify completeness after the fact.
+
+## The ingest additions
+
+- [ ] **The source page exists in the correct `wiki/sources/` subdirectory** at full depth standard. Frontmatter passes [`../procedures/verify-frontmatter-completeness.md`](../procedures/verify-frontmatter-completeness.md). The page has a `## Source Materials` footer pointing to existing files.
+- [ ] **All relevant entity and concept pages were updated or created.** Entity updates use the partial structure defined in [`../procedures/entity-partials.md`](../procedures/entity-partials.md): edits to `wiki/entities/<slug>/timeline.md` and (if applicable) `wiki/entities/<slug>/researchers.md`, never to MOC or analysis transclusion sites.
+- [ ] **Relevant MOCs include the new reading-path entry**, inserted in the position the MOC's ordering principle dictates (not appended at the end). Per [`../procedures/moc-update.md`](../procedures/moc-update.md).
+- [ ] **`wiki/index.md` and `raw/index.md` and `raw/download_arxiv_papers.py` are in sync** with the new source. Per [`../procedures/update-index-and-assets.md`](../procedures/update-index-and-assets.md).
+- [ ] **`raw/checklist.md` includes a new row for the ingested paper** with the eight columns filled per [`../procedures/raw-checklist-row.md`](../procedures/raw-checklist-row.md). The bijection holds: every arXiv paper in `raw/index.md`'s "Canonical PDFs" table has exactly one row in `raw/checklist.md`. No `reference/pdf/...` paths.
+- [ ] **Every numbered direction in `frontier-research-directions.md` and every numbered tension in `contradictions.md` was reviewed individually**, not just the page as a whole. Per [`../procedures/living-analyses-review.md`](../procedures/living-analyses-review.md). The high-level "is this page relevant?" question hides individual matches.
+- [ ] **All living analyses were reviewed per item**, not just per page. Per [`../procedures/living-analyses-review.md`](../procedures/living-analyses-review.md). The current set is enumerated in the fragment.
+- [ ] **The [stale count sweep](../procedures/stale-count-sweep.md) was performed**, every common-offender file re-verified by name. Already in [`base.md`](base.md), but elevated here because ingest is the highest-leverage place for the sweep.
+- [ ] **`README.md` badge counts, paragraph text, and per-thread `(N papers)` summary headers all reflect the new count.**
+- [ ] **The work was committed and pushed** per [`../procedures/commit-and-push.md`](../procedures/commit-and-push.md). Research files on `master`; workflow files on a feature branch + PR. Pre-existing in-progress work in the working tree was not staged.
+
+## Used by
+
+- `workflows/ingest.md`
+- `workflows/batch-ingest.md`
+- `workflows/gap-analysis.md`

--- a/workflows/_shared/glossary.md
+++ b/workflows/_shared/glossary.md
@@ -1,8 +1,8 @@
 # Glossary
 
-Canonical names for concepts that have drifted across existing workflows. Workflows MUST use the canonical term in new prose. The lint workflow's terminology check (expected, PR 2b) flags drift variants for normalization.
+Canonical names for concepts that have drifted across existing workflows. Workflows MUST use the canonical term in new prose. The lint workflow's terminology check flags drift variants for normalization.
 
-This glossary expands the seed in [`../CONVENTIONS.md`](../CONVENTIONS.md). When you add a new term, add it here and remove it from the seed. The seed is being deprecated in favor of this fragment.
+This glossary is the single source of truth for canonical terminology — `workflows/CONVENTIONS.md` points here and contains no inline glossary. When you encounter a term that drifts, add it here.
 
 ## Terms
 
@@ -89,12 +89,12 @@ This glossary expands the seed in [`../CONVENTIONS.md`](../CONVENTIONS.md). When
 ## How this glossary is enforced
 
 - **Authoring time:** Workflows reference this glossary when introducing new prose. Use the canonical term, not a drift variant.
-- **Lint time:** The lint workflow's terminology check (expected, PR 2b) greps for drift variants and flags them for normalization.
+- **Lint time:** The lint workflow's terminology check greps for drift variants and flags them for normalization.
 - **Review time:** The review workflow surfaces drift variants in its findings list.
 
 ## Used by
 
-- `workflows/CONVENTIONS.md` (the seed glossary will be removed once this fragment is referenced from the main workflows; until then, both exist with this fragment as the canonical source)
-- `workflows/lint.md` (expected, PR 2b — terminology check)
-- `workflows/review.md` (expected, PR 2b — terminology drift in findings)
-- All workflow files (expected, PR 2b — every workflow that uses any term in this glossary should use the canonical form)
+- `workflows/CONVENTIONS.md` (one-line pointer; CONVENTIONS.md no longer carries a seed glossary)
+- `workflows/lint.md` (terminology drift scan, Procedure step 6)
+- `workflows/review.md` (terminology drift scan, Procedure step 9)
+- All workflow files (every workflow that uses any term in this glossary should use the canonical form)

--- a/workflows/_shared/procedures/bulk-source-rename.md
+++ b/workflows/_shared/procedures/bulk-source-rename.md
@@ -38,5 +38,5 @@ Return to the calling workflow and proceed with its next numbered step. This fra
 
 ## Used by
 
-- `workflows/lint.md` (expected, PR 2b — Redundancy & Dead-Reference Audit, section C, replacing the inlined "Bulk source-page rename" section)
-- `workflows/enrich.md` (expected, PR 2b — when a slug change is part of the pass)
+- `workflows/lint.md` (Redundancy & Dead-Reference Audit, section C, replacing the inlined "Bulk source-page rename" section)
+- `workflows/enrich.md` (when a slug change is part of the pass)

--- a/workflows/_shared/procedures/commit-and-push.md
+++ b/workflows/_shared/procedures/commit-and-push.md
@@ -49,9 +49,10 @@ Return to the calling workflow and proceed with its next numbered step. This fra
 
 ## Used by
 
-- `workflows/ingest.md` (expected, PR 2b — Procedure step 15, replacing the current one-line pointer)
-- `workflows/batch-ingest.md` (expected, PR 2b — final consolidation step)
-- `workflows/gap-analysis.md` (expected, PR 2b — Phase 6, replacing the inlined long form that this fragment is sourced from)
-- `workflows/enrich.md` (expected, PR 2b — final step)
-- `workflows/synthesize.md` (expected, PR 2b — final step)
-- `workflows/enrichment-audit.md` (expected, PR 2b — Phase 4 final step)
+- `workflows/ingest.md` (Procedure step 13)
+- `workflows/batch-ingest.md` (Procedure step 7)
+- `workflows/gap-analysis.md` (Phase 6 — this fragment is the canonical home of the procedure that used to live inline in Phase 6)
+- `workflows/enrich.md` (Procedure step 6)
+- `workflows/synthesize.md` (Procedure step 8)
+- `workflows/enrichment-audit.md` (Phase 4 step 5)
+- `workflows/moc-gap-analysis.md` (Procedure step 12)

--- a/workflows/_shared/procedures/moc-update.md
+++ b/workflows/_shared/procedures/moc-update.md
@@ -31,5 +31,5 @@ Return to the calling workflow and proceed with its next numbered step. This fra
 
 ## Used by
 
-- `workflows/ingest.md` (expected, PR 2b — Procedure step 8)
-- `workflows/batch-ingest.md` (expected, PR 2b — once per ingested paper, before consolidation)
+- `workflows/ingest.md` (Procedure step 8)
+- `workflows/batch-ingest.md` (once per ingested paper, before consolidation)

--- a/workflows/_shared/procedures/parallel-subagent-protocol.md
+++ b/workflows/_shared/procedures/parallel-subagent-protocol.md
@@ -53,8 +53,8 @@ Return to the calling workflow and proceed with its next numbered step. This fra
 
 ## Used by
 
-- `workflows/batch-ingest.md` (expected, PR 2b — Procedure step 2, replacing the inlined "Launch parallel subagents" enumeration)
-- `workflows/verification.md` (expected, PR 2b — Procedure step 3, "Run the content accuracy check in parallel")
-- `workflows/moc-gap-analysis.md` (expected, PR 2b — Procedure steps 8–11, "Use parallel subagents if creating 2+ MOCs")
-- `workflows/enrichment-audit.md` (expected, PR 2b — Phase 3, "Execute in Parallel")
-- `workflows/plugin-audit.md` (expected, PR 2b — Procedure step 3, "Bulk fix any issues found using parallel subagents")
+- `workflows/batch-ingest.md` (Procedure step 2, replacing the inlined "Launch parallel subagents" enumeration)
+- `workflows/verification.md` (Procedure step 3, "Run the content accuracy check in parallel")
+- `workflows/moc-gap-analysis.md` (Procedure steps 8–11, "Use parallel subagents if creating 2+ MOCs")
+- `workflows/enrichment-audit.md` (Phase 3, "Execute in Parallel")
+- `workflows/plugin-audit.md` (Procedure step 3, "Bulk fix any issues found using parallel subagents")

--- a/workflows/_shared/procedures/raw-checklist-row.md
+++ b/workflows/_shared/procedures/raw-checklist-row.md
@@ -45,6 +45,6 @@ Return to the calling workflow and proceed with its next numbered step. This fra
 
 ## Used by
 
-- `workflows/ingest.md` (expected, PR 2b — Procedure step 10)
-- `workflows/batch-ingest.md` (expected, PR 2b — once per ingested paper)
-- `workflows/gap-analysis.md` (expected, PR 2b — Phase 5 ingest substep)
+- `workflows/ingest.md` (Procedure step 10)
+- `workflows/batch-ingest.md` (once per ingested paper)
+- `workflows/gap-analysis.md` (Phase 5 ingest substep)

--- a/workflows/_shared/procedures/spot-check-agent-output.md
+++ b/workflows/_shared/procedures/spot-check-agent-output.md
@@ -33,7 +33,7 @@ Return to the calling workflow and proceed with its next numbered step. This fra
 
 ## Used by
 
-- `workflows/enrichment-audit.md` (expected, PR 2b — Phase 4 step 4, replacing the inlined "Spot-check agent output" line)
-- `workflows/verification.md` (expected, PR 2b — as the entry-point lightweight check before the heavier per-page review subagents are dispatched)
-- `workflows/batch-ingest.md` (expected, PR 2b — after parallel ingest phase, before consolidation)
-- `workflows/moc-gap-analysis.md` (expected, PR 2b — after parallel MOC-creation subagents complete)
+- `workflows/enrichment-audit.md` (Phase 4 step 4, replacing the inlined "Spot-check agent output" line)
+- `workflows/verification.md` (as the entry-point lightweight check before the heavier per-page review subagents are dispatched)
+- `workflows/batch-ingest.md` (after parallel ingest phase, before consolidation)
+- `workflows/moc-gap-analysis.md` (after parallel MOC-creation subagents complete)

--- a/workflows/_shared/procedures/update-index-and-assets.md
+++ b/workflows/_shared/procedures/update-index-and-assets.md
@@ -44,8 +44,8 @@ Return to the calling workflow and proceed with its next numbered step. This fra
 
 ## Used by
 
-- `workflows/ingest.md` (expected, PR 2b — Procedure steps 7, 9, 10, replacing the inlined directory-tree update + raw/index.md + downloader update)
-- `workflows/batch-ingest.md` (expected, PR 2b — Procedure step 4, the consolidation pass)
-- `workflows/enrich.md` (expected, PR 2b — Procedure steps 4, 5, 6, the index/raw/downloader sync sub-steps)
-- `workflows/synthesize.md` (expected, PR 2b — Procedure step 5, "Update `wiki/index.md` and any relevant MOCs")
-- `workflows/enrichment-audit.md` (expected, PR 2b — Phase 4 step 1, "Update `wiki/index.md` with new or changed page counts and entries")
+- `workflows/ingest.md` (Procedure steps 7, 9, 10, replacing the inlined directory-tree update + raw/index.md + downloader update)
+- `workflows/batch-ingest.md` (Procedure step 4, the consolidation pass)
+- `workflows/enrich.md` (Procedure steps 4, 5, 6, the index/raw/downloader sync sub-steps)
+- `workflows/synthesize.md` (Procedure step 5, "Update `wiki/index.md` and any relevant MOCs")
+- `workflows/enrichment-audit.md` (Phase 4 step 1, "Update `wiki/index.md` with new or changed page counts and entries")

--- a/workflows/_shared/procedures/verify-frontmatter-completeness.md
+++ b/workflows/_shared/procedures/verify-frontmatter-completeness.md
@@ -47,7 +47,8 @@ Return to the calling workflow and proceed with its next numbered step. This fra
 
 ## Used by
 
-- `workflows/ingest.md` (expected, PR 2b — Procedure step 4, "Create a source summary page")
-- `workflows/review.md` (expected, PR 2b — Procedure step 2, "Spot-check that all pages have required frontmatter fields")
-- `workflows/plugin-audit.md` (expected, PR 2b — Procedure step 2, Pandoc compliance check; the universal-minimum check covers the `title:` requirement)
-- `workflows/verification.md` (expected, PR 2b — Procedure step 2, "Confirm frontmatter is complete and consistent")
+- `workflows/ingest.md` (Procedure step 4, "Create a source page")
+- `workflows/enrich.md` (Procedure step 3, raw asset linking pass)
+- `workflows/review.md` (Procedure step 2, "Spot-check that all pages have required frontmatter fields")
+- `workflows/plugin-audit.md` (Procedure step 2, Pandoc compliance check; the universal-minimum check covers the `title:` requirement)
+- `workflows/verification.md` (Procedure step 2, "Confirm frontmatter is complete and consistent")

--- a/workflows/_shared/rules/frontmatter-schema.md
+++ b/workflows/_shared/rules/frontmatter-schema.md
@@ -59,7 +59,7 @@ Phantom file path entries in `source_file:`, `latex_source:`, or `venue_pdfs:` p
 
 - `workflows/_shared/procedures/verify-frontmatter-completeness.md` — canonical schema source for the per-page check
 - `workflows/_shared/procedures/raw-checklist-row.md` — the raw-checklist row format depends on `source_file:` and `latex_source:` field consistency
-- `workflows/schema-self-audit.md` (expected, PR 2b)
-- `workflows/lint.md` (expected, PR 2b)
-- `workflows/ingest.md`, `workflows/batch-ingest.md` (expected, PR 2b — page creation must conform)
-- `workflows/review.md`, `workflows/plugin-audit.md`, `workflows/verification.md` (expected, PR 2b — verification consumers)
+- `workflows/schema-self-audit.md`
+- `workflows/lint.md`
+- `workflows/ingest.md`, `workflows/batch-ingest.md` (page creation must conform)
+- `workflows/review.md`, `workflows/plugin-audit.md`, `workflows/verification.md` (verification consumers)

--- a/workflows/_shared/rules/log-immutability.md
+++ b/workflows/_shared/rules/log-immutability.md
@@ -32,4 +32,4 @@ This rule has been enforced multiple times after near-misses where bulk-update p
 - `workflows/_shared/procedures/stale-count-sweep.md` (canonical exclusion)
 - `workflows/_shared/procedures/bulk-source-rename.md` (canonical exclusion)
 - `workflows/CONVENTIONS.md` Meta-rules (this rule is also stated as a meta-rule there; the rule fragment is the canonical long form)
-- `workflows/ingest.md`, `workflows/batch-ingest.md`, `workflows/lint.md`, `workflows/review.md`, `workflows/enrich.md`, `workflows/synthesize.md`, `workflows/gap-analysis.md`, `workflows/enrichment-audit.md` (expected, PR 2b — every workflow that appends to log.md must respect this rule)
+- `workflows/ingest.md`, `workflows/batch-ingest.md`, `workflows/lint.md`, `workflows/review.md`, `workflows/enrich.md`, `workflows/synthesize.md`, `workflows/gap-analysis.md`, `workflows/enrichment-audit.md` (every workflow that appends to log.md must respect this rule)

--- a/workflows/_shared/rules/path-discipline.md
+++ b/workflows/_shared/rules/path-discipline.md
@@ -50,5 +50,5 @@ The `reference/` prefix predates a directory reorganization that moved everythin
 - `workflows/_shared/procedures/raw-checklist-row.md` (canonical row format that enforces the prefixes)
 - `workflows/_shared/procedures/verify-frontmatter-completeness.md` (per-page check that validates path resolution)
 - `workflows/_shared/rules/frontmatter-schema.md` (the conditional `venue_pdfs:` clause references this rule)
-- `workflows/ingest.md`, `workflows/batch-ingest.md` (expected, PR 2b — applies to every page-creation step)
-- `workflows/lint.md` (expected, PR 2b — applies to phantom detection sub-pass)
+- `workflows/ingest.md`, `workflows/batch-ingest.md` (applies to every page-creation step)
+- `workflows/lint.md` (applies to phantom detection sub-pass)

--- a/workflows/_shared/rules/shared-file-off-limits.md
+++ b/workflows/_shared/rules/shared-file-off-limits.md
@@ -49,7 +49,7 @@ The cost of forbidding subagent edits to these files is small (the coordinator c
 
 - `workflows/_shared/procedures/parallel-subagent-protocol.md` — enforces the rule at subagent dispatch time. Subagent prompts MUST include the enumeration and the "report, do not edit" instruction.
 - `workflows/_shared/procedures/spot-check-agent-output.md` — would surface unexpected edits to coordinator-only files in the post-phase sample.
-- `workflows/verification.md` (expected, PR 2b) — full verification pass would catch any edits to coordinator-only files in the parallel-phase output.
+- `workflows/verification.md` — full verification pass would catch any edits to coordinator-only files in the parallel-phase output.
 - Manual: `git diff --stat` on the parallel-phase output should show zero changes to any file in this enumeration.
 
 ## How to extend the enumeration
@@ -61,4 +61,4 @@ When a new file becomes coordinator-only — typically because a workflow change
 - `workflows/_shared/procedures/parallel-subagent-protocol.md` (canonical enforcement point — every subagent dispatch consumes this enumeration)
 - `workflows/_shared/procedures/spot-check-agent-output.md` (post-phase verification reference)
 - `workflows/_shared/procedures/commit-and-push.md` (the "do not touch" bucket overlaps with this enumeration)
-- `workflows/batch-ingest.md`, `workflows/verification.md`, `workflows/moc-gap-analysis.md`, `workflows/enrichment-audit.md`, `workflows/plugin-audit.md` (expected, PR 2b — replacing each workflow's drifted inline enumeration)
+- `workflows/batch-ingest.md`, `workflows/verification.md`, `workflows/moc-gap-analysis.md`, `workflows/enrichment-audit.md`, `workflows/plugin-audit.md` (replacing each workflow's drifted inline enumeration)

--- a/workflows/_shared/rules/slug-disambiguation.md
+++ b/workflows/_shared/rules/slug-disambiguation.md
@@ -36,7 +36,7 @@ The "in the same `wiki/sources/**/` directory" qualifier matters because cross-d
 
 ## Used by
 
-- `workflows/ingest.md` (expected, PR 2b — Procedure step 3, "Pick a slug")
-- `workflows/batch-ingest.md` (expected, PR 2b — applies to every paper in the batch)
-- `workflows/lint.md` (expected, PR 2b — Redundancy & Dead-Reference Audit, section C)
+- `workflows/ingest.md` (Procedure step 3, "Pick a slug")
+- `workflows/batch-ingest.md` (applies to every paper in the batch)
+- `workflows/lint.md` (Redundancy & Dead-Reference Audit, section C)
 - `workflows/_shared/procedures/bulk-source-rename.md` — the retroactive fix when this rule was violated

--- a/workflows/batch-ingest.md
+++ b/workflows/batch-ingest.md
@@ -69,34 +69,29 @@ Use this workflow to ingest `3+` sources in parallel, keep per-paper work isolat
 
 - The full list of papers or source files to ingest.
 - Any theme grouping that helps assign work cleanly.
-- Awareness that shared files are off-limits for subagents: `wiki/index.md`, `wiki/log.md`, MOCs, `AGENTS.md`, `raw/index.md`, and `wiki/overview-state-of-field.md`.
+- The canonical list of coordinator-only files that subagents must not edit, in [`_shared/rules/shared-file-off-limits.md`](_shared/rules/shared-file-off-limits.md).
 
 ## Procedure
 
 1. Identify every paper to ingest and group them by theme when that reduces overlap.
-2. Launch parallel subagents, one per paper, and give each agent a narrow prompt:
-   - Own only its assigned source page and any directly related concept or entity pages.
-   - Use the full `Ingest` workflow for that one paper.
-   - Do not edit shared files.
-   - Preserve factual accuracy, source citations, and file-path conventions.
-3. Keep the subagent prompt explicit about scope boundaries.
-   - Example instruction: "Refactor only the pages for `paper X`; do not touch shared indexes or MOCs."
-   - Example instruction: "If you need a shared file, report it instead of editing it."
-4. After all subagents complete, consolidate shared files yourself:
-   - Update `wiki/index.md` with all new pages and verify directory tree counts.
-   - Update relevant MOCs with new reading-path entries.
-   - Update `raw/index.md` with new assets.
-   - Append all log entries to `wiki/log.md` in chronological order.
-   - Check living analyses: `contradictions.md`, `open-questions.md`, and `benchmark-overlap.md`.
-5. Run the `Verification` workflow on all subagent output.
+2. **Dispatch the parallel subagents under the protocol.** Run [parallel subagent protocol](_shared/procedures/parallel-subagent-protocol.md) in full, then return here and continue with step 3. The fragment owns: per-agent scope boundaries, the canonical coordinator-only file enumeration, the report-not-edit instruction, and the dispatch contract. Each subagent's task is "run `workflows/ingest.md` end-to-end on paper X" — the protocol fragment's invariants ensure the per-paper work stays isolated.
+3. **Spot-check the agent output.** Run [spot check agent output](_shared/procedures/spot-check-agent-output.md), then return here and continue with step 4. If the spot check escalates (2+ issues across the sample), pause and run `workflows/verification.md` in full before consolidation.
+4. **Consolidate the coordinator-only files** that subagents could not touch:
+   - Run [update index and assets](_shared/procedures/update-index-and-assets.md) once for the whole batch (the fragment's count step uses the post-batch filesystem, so it produces correct counts in one pass).
+   - Run [moc update](_shared/procedures/moc-update.md) once per affected MOC (one call per reading path that gained an entry, not one call per ingested paper).
+   - Run [stale count sweep](_shared/procedures/stale-count-sweep.md) — the count drift from a multi-paper batch is the highest-leverage place for the sweep.
+   - Run [living analyses review](_shared/procedures/living-analyses-review.md) — every numbered direction in `frontier-research-directions.md` and every numbered tension in `contradictions.md` must be reviewed individually, even though the new pages came from different agents.
+   - Append a single chronological-order entry per paper to `wiki/log.md`.
+5. Run the `Verification` workflow on all subagent output. The spot check in step 3 is the lightweight first pass; verification is the heavyweight per-page review.
 6. Update `wiki/overview-state-of-field.md` if the batch materially changes the field picture.
+7. **Commit and push.** Run [commit and push](_shared/procedures/commit-and-push.md) in full. The fragment owns the research-vs-workflow split, the explicit-path staging discipline, the `Co-Authored-By` trailer requirement, and the feature-branch + PR rule for any workflow file changes.
 
 ## Completion Checklist
 
+- All items in [`_shared/checklists/base.md`](_shared/checklists/base.md) hold.
+- All items in [`_shared/checklists/ingest-additions.md`](_shared/checklists/ingest-additions.md) hold (each ingested paper must satisfy them, even though the per-paper work was done by a subagent).
 - Every source was assigned to exactly one subagent.
-- No subagent touched shared files.
-- Shared indexes and logs were consolidated after all agents finished.
-- Verification was run on the final output.
+- The spot check passed (or the escalation to full verification was performed before consolidation).
 - The overview page was updated only if the batch changed the field narrative.
 
 ## Related Workflows

--- a/workflows/enrich.md
+++ b/workflows/enrich.md
@@ -86,31 +86,28 @@ Use this workflow when the wiki already has content and you need to clean up str
 
 ## Procedure
 1. Run a lightweight MOC Gap Analysis:
-   - Check whether any theme has 5+ uncovered pages.
-   - Update existing MOCs when new pages are added to their theme.
-- Verify the `AGENTS.md` Current MOCs list matches actual MOC files.
+   - Check whether any theme has 5+ uncovered pages (a full check belongs to `workflows/moc-gap-analysis.md`; this is a quick scan).
+   - For each existing MOC whose reading path needs an update, run [moc update](_shared/procedures/moc-update.md), then return here and continue.
+   - Verify the `AGENTS.md` Current MOCs list matches actual MOC files.
 2. Audit backlinks:
    - Scan for entity and concept names mentioned in prose but not wiki-linked.
    - Add missing links.
    - Check that cross-concept references are bidirectional where the connection is discussed on both sides.
 3. Verify raw asset linking:
-   - Ensure all source pages have `source_file:`, `latex_source:`, and `venue_pdfs:` when applicable.
+   - Run [verify frontmatter completeness](_shared/procedures/verify-frontmatter-completeness.md) on each source page touched by the pass, then return here.
    - Ensure all source pages include a `## Source Materials` footer.
    - Add section-specific PDF citations like `[[raw/pdf/file.pdf|Paper §X]]` to concept pages for key claims.
-4. Sync indexes:
-   - Verify `wiki/index.md` directory tree counts match actual page counts.
-   - Verify all pages appear in the appropriate index sections.
-5. Update `raw/index.md` if new PDFs or LaTeX sources were added.
-6. Update `raw/download_arxiv_papers.py` if arXiv assets were added so the download list stays reproducible.
-7. Update `wiki/log.md` with what changed.
+4. **Sync indexes and assets.** Run [update index and assets](_shared/procedures/update-index-and-assets.md) in full, then return here and continue with step 5. The fragment owns: `wiki/index.md` directory-tree counts and entry-list updates, `raw/index.md` PDF/LaTeX/venue-PDF tables, and `raw/download_arxiv_papers.py` reproducibility.
+5. Update `wiki/log.md` with what changed.
+6. **Commit and push.** Run [commit and push](_shared/procedures/commit-and-push.md) in full.
+
+If the pass turns up a slug-collision rename, follow [bulk source rename](_shared/procedures/bulk-source-rename.md) — it is the only context where `sed` is the blessed tool, and the verification step is non-negotiable.
 
 ## Completion Checklist
+- All items in [`_shared/checklists/base.md`](_shared/checklists/base.md) hold.
 - MOC coverage gaps were checked and only expected gaps remain.
 - Internal links are present where prose refers to entities or concepts.
 - Source pages expose required asset metadata and source-material footers.
-- Index counts and page listings match the actual vault state.
-- Any arXiv-related changes are reflected in `raw/download_arxiv_papers.py`.
-- The work is logged in `wiki/log.md`.
 
 ## Related Workflows
 - `workflows/lint.md`

--- a/workflows/enrichment-audit.md
+++ b/workflows/enrichment-audit.md
@@ -111,30 +111,21 @@ Data-driven gap-finding pass that inventories enrichment opportunities across th
 
 ### Phase 3: Execute in Parallel
 1. Create one task per independent workstream, such as expanding thin source pages, deepening concept pages, or creating a benchmark analysis.
-2. Launch parallel agent teams, one agent per task.
-3. Give each agent:
-   - The specific files to read and modify.
-   - The wiki conventions for frontmatter, linking, and depth.
-   - Clear file ownership boundaries to avoid merge conflicts.
-4. Keep shared files off-limits for agents:
-   - `index.md`
-   - `log.md`
-   - `overview-state-of-field.md`
-   - MOCs
-5. Track completion as tasks finish and report results incrementally to the user.
+2. **Dispatch the parallel agents under the protocol.** Run [parallel subagent protocol](_shared/procedures/parallel-subagent-protocol.md) in full, then return here and continue with Phase 4. The fragment owns: per-agent scope boundaries, the canonical coordinator-only file enumeration (replacing the drifted 4-item list this phase used to inline), the report-not-edit instruction, and the dispatch contract. Track completion as tasks finish and report results incrementally to the user — the protocol fragment makes this explicit.
 
 ### Phase 4: Consolidate
-1. Update `wiki/index.md` with new or changed page counts and entries.
-2. Append all activity to `wiki/log.md`.
-3. Update MOCs if new content changes reading paths.
-4. Spot-check agent output, including a sample of numbers, links, and frontmatter.
+1. **Sync indexes and assets.** Run [update index and assets](_shared/procedures/update-index-and-assets.md), then return here and continue with step 2. The fragment owns the `wiki/index.md` count and entry-list updates.
+2. **Update affected MOCs.** For each MOC whose reading path gained an entry during Phase 3, run [moc update](_shared/procedures/moc-update.md). Skip if no MOC was affected.
+3. **Spot-check the agent output.** Run [spot check agent output](_shared/procedures/spot-check-agent-output.md), then return here and continue with step 4. If the spot check escalates (2+ issues across the sample), pause and run `workflows/verification.md` in full before logging.
+4. Append all activity to `wiki/log.md` as a single audit entry per workstream.
+5. **Commit and push.** Run [commit and push](_shared/procedures/commit-and-push.md) in full.
 
 ## Completion Checklist
+- All items in [`_shared/checklists/base.md`](_shared/checklists/base.md) hold.
+- All items in [`_shared/checklists/audit-additions.md`](_shared/checklists/audit-additions.md) hold.
 - All gaps are prioritized by impact.
 - User approval has been obtained before execution.
 - Parallel tasks had disjoint file ownership.
-- Shared files were updated only during consolidation.
-- `wiki/index.md`, `wiki/log.md`, and relevant MOCs are in sync.
 
 ## Related Workflows
 - `workflows/lint.md`

--- a/workflows/gap-analysis.md
+++ b/workflows/gap-analysis.md
@@ -47,15 +47,8 @@ graph TD
     end
 
     subgraph P6["Phase 6: Commit & Push"]
-        F1["Stage research files only<br/>(explicit paths, not git add -A)"]
-        F2["Commit on master with<br/>descriptive ingest message"]
-        F3["Push master to origin"]
-        F4{"Workflow files<br/>also touched?"}
-        F5["Branch + commit + push;<br/>open PR for workflow changes"]
-        F1 --> F2 --> F3 --> F4
-        F4 -->|Yes| F5
-        F4 -->|No| Done([Done])
-        F5 --> Done
+        F1["commit-and-push fragment<br/>(research → master,<br/>workflows → feature branch + PR)"]
+        F1 --> Done([Done])
     end
 
     P1 --> P2 --> P3 --> P4 --> P5 --> P6
@@ -142,16 +135,8 @@ This workflow is **proactive** — it generates new ingest work from the wiki's 
 3. **If appropriate**:
    a. Add a `PaperSpec("XXXX.XXXXX", "archive")` (or `"extract"`) entry to `raw/download_arxiv_papers.py` in arXiv-ID order.
    b. Run the downloader script: `cd raw && python download_arxiv_papers.py`. The script is idempotent — it skips files that already exist. The new paper's PDF and LaTeX archive will land in `raw/pdf/` and `raw/latex/`.
-   c. Update `raw/index.md` (PDF entry, LaTeX archive entry, summary count).
-   d. Run `workflows/ingest.md` end-to-end. Do not paraphrase its steps from memory — read the file. Specifically:
-      - Create the source page in the appropriate `wiki/sources/<theme>/` subdirectory at full depth standard.
-      - Update or create entity pages (if a new institution appears, create the page).
-      - Update concept pages with the new paper's findings.
-      - Update other source pages that the new paper directly cites or critiques.
-      - Update `wiki/index.md` directory tree counts and entity list.
-      - Update relevant MOCs.
-      - Update living analyses (`contradictions.md`, `frontier-research-directions.md`, `benchmark-overlap.md`, `open-questions.md`, `paper-timeline.md`, `method-comparison.md`).
-      - Append a comprehensive entry to `wiki/log.md`.
+   c. Update `raw/index.md` (PDF entry, LaTeX archive entry, summary count) and append the corresponding row to `raw/checklist.md` via [raw checklist row](_shared/procedures/raw-checklist-row.md). The bijection is non-negotiable: every arXiv paper in `raw/index.md`'s "Canonical PDFs" table must have exactly one row in `raw/checklist.md`.
+   d. Run `workflows/ingest.md` end-to-end. Do not paraphrase its steps from memory — read the file. The ingest workflow handles source page creation, entity/concept updates, MOC reading-path updates via [moc update](_shared/procedures/moc-update.md), index/asset sync via [update index and assets](_shared/procedures/update-index-and-assets.md), the per-item [living analyses review](_shared/procedures/living-analyses-review.md), and the log entry. Do not duplicate those steps here — the ingest workflow is the canonical procedure and changes to it must be picked up automatically.
 
 ### Phase 4: Trigger Downstream Workflows
 
@@ -192,56 +177,25 @@ For single-paper ingests, triggers 2-4 always fire; trigger 1 fires conditionall
    - Concept/source/MOC propagation — were all relevant pages updated with substantive content (not just link additions)?
    - Analysis updates — were all 6+ living analyses checked, *and was each numbered direction in `frontier-research-directions.md` and each numbered tension in `contradictions.md` reviewed individually*?
    - Overview / README / log — were the global pages updated?
-   - **Count-drift discipline** — was the stale paper-count sweep performed (`workflows/ingest.md` step 11)? Were all hardcoded counts in body prose (intros, methodology paragraphs, MOC blurbs, blind-spot bullets, README badges, README per-thread headers, `wiki/index.md` directory tree) updated to the new value? Score 0/10 if any count outside `wiki/log.md` still shows the old value.
+   - **Count-drift discipline** — was the [stale count sweep](_shared/procedures/stale-count-sweep.md) performed? Were all hardcoded counts in body prose (intros, methodology paragraphs, MOC blurbs, blind-spot bullets, README badges, README per-thread headers, `wiki/index.md` directory tree) updated to the new value? Score 0/10 if any count outside `wiki/log.md` still shows the old value.
    - Lint compliance — do all new links resolve, do all new anchors exist?
    - Workflow trigger discipline — were all downstream workflow triggers explicitly checked and acted on?
 2. **If < 10/10**: Identify the missing pieces, fix them, and re-grade. Iterate until 10/10. Do not skip this loop — it is the difference between a 7/10 ingest and a 10/10 ingest.
 3. **Append a final summary** to `wiki/log.md` with the gap statement, the chosen paper, the propagation summary, and the final grade.
 
-### Phase 6: Commit and Push (Research) + PR (Workflow Changes)
+### Phase 6: Commit and Push
 
-This phase exists because uncommitted ingest work is fragile (it can be lost to a tab crash, an accidental `git restore`, or a context-window reset on the next session) and because workflow changes deserve explicit review even when research changes are routine. The split is based on **blast radius**: research files are content-only and reviewed continuously by the user, so they ship straight to `master`; workflow files change *how future ingests are run* and benefit from a PR review surface.
-
-1. **Identify which files belong to which bucket** before staging anything. Walk the output of `git status` and classify each modified file:
-   - **Research bucket** (commit on `master`): `wiki/**`, `raw/**`, `README.md`, anything created or updated by the ingest itself.
-   - **Workflow bucket** (PR): `workflows/**`, `AGENTS.md` (if the workflow index changed), and any new schema/process documentation.
-   - **Do not touch**: any modified file you did *not* write to during this session. Pre-existing in-progress work in the working tree must not be staged. The session-start `git status` (captured in the system context) is the source of truth for what was already dirty before you began.
-
-2. **Stage the research files explicitly by path**, not with `git add -A` or `git add .`. Explicit paths prevent accidentally staging the user's pre-existing in-progress work, the `.codex/` or `.mcp.json` shells, or `.obsidian/graph.json` auto-saves. Verify with `git status` that the staged set matches your research bucket exactly and that the workflow files remain unstaged.
-
-3. **Commit on `master`** with a descriptive message that names the paper, summarizes the contribution, lists created/updated pages, and notes any cleanup work bundled in (e.g., paper-count sweeps, checklist resync). Follow the existing repo style (`git log --oneline -5` to compare). Always include the `Co-Authored-By` trailer.
-
-4. **Push `master`** to `origin`. The research commit is now durable.
-
-5. **If workflow files were also touched**, create a PR for them — do not commit workflow changes directly to `master`:
-   a. `git checkout -b workflow-<short-descriptor>` (e.g. `workflow-improvements-gap-analysis-discipline`). The branch starts from current `master` so the unstaged workflow changes carry over automatically.
-   b. Stage the workflow files explicitly (`workflows/*.md` and any related schema files).
-   c. Commit on the branch with a message that explains the *regression class* the workflow change prevents, not just the line-level diff. (E.g. "Add per-direction analysis review + count-drift sweep + checklist sync to ingest workflow" with a body explaining what was missed in the most recent run.)
-   d. `git push -u origin <branch>`.
-   e. `gh pr create --title "..." --body "..."` with a body that includes a Summary section (regression classes addressed) and a Test plan section (how to verify the new instructions work on the next ingest).
-   f. Return to `master` (`git checkout master`) so subsequent work does not accidentally land on the PR branch.
-
-6. **If only research files were touched**, skip step 5 — no PR needed.
-
-The rationale for splitting: research changes are continuous and trusted (the user reviews them directly via the wiki). Workflow changes are meta-level — they shape every future ingest — so they deserve a PR review surface even if the author is the same. This is the same defense-in-depth principle as the count-drift sweep: catch regressions at the boundary where they are cheapest to fix.
+Run [commit and push](_shared/procedures/commit-and-push.md) in full. The fragment owns the research-vs-workflow split, the explicit-path staging discipline, the `Co-Authored-By` trailer requirement, and the feature-branch + PR rule for any workflow file changes. This phase used to be the canonical inline source for that procedure; the fragment is now the canonical source and the procedure must be invoked via the call, not paraphrased here.
 
 ## Completion Checklist
 
+- All items in [`_shared/checklists/base.md`](_shared/checklists/base.md) hold.
+- All items in [`_shared/checklists/ingest-additions.md`](_shared/checklists/ingest-additions.md) hold (the inner ingest workflow's checklist is required because gap-analysis Phase 3 invokes it).
 - A specific gap was identified from the wiki's own analysis pages (not invented).
 - arXiv MCP was used for search, abstract triage, and download (not WebSearch).
 - The chosen paper was checked for appropriateness with explicit reasoning before ingest.
-- The downloader script (`raw/download_arxiv_papers.py`) was updated and run.
-- `raw/index.md` was updated with the new PDF and LaTeX entries and summary counts.
-- `raw/checklist.md` was updated with a new row for the chosen paper (URL audit trail, parallel to `raw/index.md`'s asset map).
-- `workflows/ingest.md` was followed end-to-end (source page + entities + concepts + MOCs + analyses + index + log).
-- **Stale paper-count sweep performed** (per `workflows/ingest.md` step 11). Grepped `wiki/` for the old count and updated every match outside `wiki/log.md`. Re-verified the seven common-offender files by name: `wiki/analyses/frontier-research-directions.md`, `wiki/analyses/benchmark-overlap.md`, `wiki/analyses/paper-timeline.md`, `wiki/analyses/latentcompress-collaboration-strategy.md`, `wiki/mocs/practical-systems.md`, `wiki/overview-state-of-field.md`, `README.md`. Confirmed `wiki/log.md` historical entries were left untouched.
-- Every numbered direction in `frontier-research-directions.md` and every numbered tension in `contradictions.md` was reviewed *individually* (not just the analysis page as a whole) — a single new paper often updates multiple directions/tensions and the page-level "is this relevant?" question hides individual matches.
 - All Phase 4 downstream workflow triggers were explicitly checked and acted on (or explicitly noted as not firing).
-- Lint sweep verified no broken wiki-links or anchors were introduced.
 - The run was self-graded against the rubric and any < 10/10 items were fixed.
-- A comprehensive entry was appended to `wiki/log.md` documenting the full propagation.
-- **Phase 6 executed**: research files staged by explicit path (not `git add -A`), committed on `master` with a descriptive message including the `Co-Authored-By` trailer, and pushed to `origin`. Pre-existing in-progress work in the working tree was *not* staged.
-- **If workflow files were touched**: a feature branch was created, workflow files were committed on the branch, the branch was pushed, and a PR was opened with a Summary + Test plan body. The branch name follows `workflow-<descriptor>` and the local checkout was returned to `master` after the PR was created.
 
 ## Related Workflows
 

--- a/workflows/ingest.md
+++ b/workflows/ingest.md
@@ -6,13 +6,13 @@ graph TD
     B --> C["Create Source Page"]
     C --> D["Update Entity &<br/>Concept Pages"]
     D --> E["Update Institution<br/>Entity Pages"]
-    E --> F["Update wiki/index.md"]
-    F --> G["Update MOC<br/>Reading Paths"]
-    G --> H["Update arXiv<br/>Downloader Script"]
-    H --> I["Update raw/index.md<br/>Asset Mapping"]
-    I --> J["Check Living<br/>Analyses"]
-    J --> K["Append to<br/>wiki/log.md"]
+    E --> F["update-index-and-assets<br/>(wiki/index, raw/index,<br/>downloader, checklist row)"]
+    F --> G["moc-update<br/>per affected MOC"]
+    G --> J["living-analyses-review<br/>(per item)"]
+    J --> J2["stale-count-sweep"]
+    J2 --> K["Append to<br/>wiki/log.md"]
     K --> L["Report Outcome<br/>to User"]
+    L --> M["commit-and-push"]
 
     subgraph read ["Input & Reading"]
         A
@@ -31,14 +31,14 @@ graph TD
         E
         F
         G
-        H
-        I
         J
+        J2
     end
 
     subgraph complete ["Completion & Reporting"]
         K
         L
+        M
     end
 
     style read fill:#dae8fc,stroke:#6c8ebf,color:#333
@@ -82,49 +82,29 @@ Do not use this workflow when the task is only to answer a question, run a lint 
 1. Read the source file in `raw/`.
 2. Discuss key takeaways with the user. Ask what to emphasize if unclear.
 3. **Pick a slug that disambiguates by default.** Before creating the file, `Glob wiki/sources/**/*.md` and check whether the leading hyphen-token of your candidate slug already exists (e.g., another `kvcomm-*` or `coconut-*`). If it does, use the hybrid form `<technique>-<institution>-<distinguisher>.md` so collisions never accumulate.
-4. Create a source summary page in the appropriate `wiki/sources/` subdirectory. Include:
-   - Full frontmatter: `type`, `title`, `source_file`, `latex_source` (if available), `author`, `date_published`, `date_ingested`, `created`, `tags`.
-   - If venue duplicate PDFs exist **and the file is actually present in `raw/pdf/`**, add `venue_pdfs:`. **Never list a venue PDF you have not downloaded** — verify each path with `Glob` before writing the frontmatter. Phantom `venue_pdfs:` entries propagate into `raw/index.md` and break lint passes weeks later.
-   - A `## Source Materials` footer linking to the PDF and LaTeX source. Both paths must already exist on disk.
-   - Section-specific detail per the depth standard.
+4. Create a source page in the appropriate `wiki/sources/` subdirectory.
+   - Author the frontmatter, then run [verify frontmatter completeness](_shared/procedures/verify-frontmatter-completeness.md) in full and return here before continuing. The fragment is the canonical schema; per-type field lists live there, not here.
+   - **Conditional `venue_pdfs:`**: only list a venue PDF when the file is actually present in `raw/pdf/` — verify each path with `Glob` before writing the frontmatter. Phantom `venue_pdfs:` entries propagate into `raw/index.md` and break lint passes weeks later. (This invariant is repeated inline because losing it in delegation has bitten previous ingests; the fragment also enforces it.)
+   - Add a `## Source Materials` footer linking to the PDF and LaTeX source. Both paths must already exist on disk.
+   - Fill in section-specific detail per the depth standard.
 5. For each significant entity or concept mentioned:
    - If a page exists, update it with new information and cite the new source.
    - If no page exists, create one with `title:` in frontmatter.
 6. For each institution involved, update or create the entity page. Entity pages use the **partial structure** defined in `workflows/_shared/procedures/entity-partials.md`: a narrative shell at `wiki/entities/<slug>.md` plus partials at `wiki/entities/<slug>/timeline.md` (the Contribution Timeline table) and `wiki/entities/<slug>/researchers.md` (the Key Researchers list), embedded into the shell via `![[<slug>/timeline]]` and `![[<slug>/researchers]]`.
    - **Existing entity**: edit only `wiki/entities/<slug>/timeline.md` to add a new row for the ingested paper, and `wiki/entities/<slug>/researchers.md` if the paper introduces new key researchers. Any MOC or analysis that transcludes these partials updates automatically — do not also hand-edit those consumers.
    - **New entity**: follow the "Adding a new entity under this convention" checklist in `workflows/_shared/procedures/entity-partials.md`. Create the shell, the two partials (with `type: entity-partial` frontmatter), and add the entity to `wiki/index.md`'s Entities section with the partial subdirectory reflected in the directory-tree counts.
-7. Update `wiki/index.md` and verify directory tree counts.
-8. Update relevant MOC pages (`wiki/mocs/*.md`) to add the new source or concept to the correct reading path.
-9. If the source is on arXiv, update `raw/download_arxiv_papers.py` so the downloader includes the new paper ID and the correct LaTeX storage mode (`archive` vs `extract`).
-10. Update `raw/index.md` to add the new PDF and LaTeX source to the asset mapping. **Also append a new row to `raw/checklist.md`** (the URL audit trail, parallel to `raw/index.md`'s asset map). The checklist has eight columns: `Paper | Original refs from list | Canonical PDF download | Canonical LaTeX/source download | PDF present | Local PDF | LaTeX present | Local LaTeX/source`. Fill the row as follows:
-    - **Paper**: the paper title.
-    - **Original refs from list**: `arXiv:XXXX.XXXXX` plus any venue-duplicate IDs (OpenReview, ACL, EMNLP, ICLR, NeurIPS, ICML) that appear in the "Duplicate PDFs (Venue Copies)" section of `raw/index.md` for this paper. Separate multiple refs with `;`. **Only include venue refs whose PDF is actually present in `raw/pdf/`** — same constraint as step 4's `venue_pdfs:` frontmatter.
-    - **Canonical PDF download**: `https://arxiv.org/pdf/{id}` (use the bare ID, no version suffix unless intentionally pinning).
-    - **Canonical LaTeX/source download**: `https://arxiv.org/e-print/{id}`.
-    - **PDF present** / **LaTeX present**: `Yes` once the downloader has run.
-    - **Local PDF**: `raw/pdf/arxiv-XXXX.XXXXX.pdf`. **Do not use `reference/pdf/...`** — that is a stale historical path from a pre-move vault layout and has caused drift in the past.
-    - **Local LaTeX/source**: must match the actual on-disk format chosen in `raw/download_arxiv_papers.py`. Use `raw/latex/arxiv-XXXX.XXXXX/` (trailing slash) for `extract`-mode papers whose source was unpacked into a directory, and `raw/latex/arxiv-XXXX.XXXXX.tar.gz` for `archive`-mode papers stored as a tarball.
-
-    The invariant: every arXiv paper listed in `raw/index.md`'s "Canonical PDFs" table must have exactly one corresponding row in `raw/checklist.md`. Non-arXiv sources (e.g., the latentcompress GitHub project) are intentionally excluded from the checklist.
-11. **Review living analyses per-item.** Run the [living analyses review](_shared/procedures/living-analyses-review.md) in full, then return here and continue with step 12. Every numbered direction in `frontier-research-directions.md` and every numbered tension in `contradictions.md` must be reviewed individually — the high-level "is this page relevant?" question hides individual matches.
-12. **Mandatory:** Run the [stale count sweep](_shared/procedures/stale-count-sweep.md). This is a first-class regression class — do not skip. The common-offender list and grep patterns live in the fragment; apply them against the pre-ingest count (N) and the post-ingest count (N+1 or N+k). When complete, return here and continue with step 13.
-13. Append an entry to `wiki/log.md`.
-14. Report the outcome to the user: pages created, pages updated, and any contradictions found.
-15. **Commit and push** (mirrors `workflows/gap-analysis.md` Phase 6 — apply the same discipline when ingest is invoked directly). Stage research files by explicit path (not `git add -A`); never stage pre-existing in-progress work, `.codex/`, `.mcp.json`, or `.obsidian/graph.json`. Commit on `master` with a descriptive message and the `Co-Authored-By` trailer. Push `master`. **If workflow files were also touched**, create a feature branch, commit workflow changes on the branch, push, and open a PR with a Summary + Test plan body — never commit workflow changes directly to `master`. See `workflows/gap-analysis.md` Phase 6 for the full procedure.
+7. **Sync indexes and assets.** Run [update index and assets](_shared/procedures/update-index-and-assets.md) in full, then return here and continue with step 8. The fragment owns: `wiki/index.md` directory-tree counts and entry-list updates, `raw/index.md` PDF/LaTeX/venue-PDF tables, `raw/download_arxiv_papers.py` reproducibility, and the appended row in `raw/checklist.md` via [raw checklist row](_shared/procedures/raw-checklist-row.md).
+8. **Update relevant MOC reading paths.** For each MOC whose theme the new source touches, run [moc update](_shared/procedures/moc-update.md), then return here and continue with step 9. Insert each new entry in the position the MOC's ordering principle dictates — not appended at the end.
+9. **Review living analyses per-item.** Run the [living analyses review](_shared/procedures/living-analyses-review.md) in full, then return here and continue with step 10. Every numbered direction in `frontier-research-directions.md` and every numbered tension in `contradictions.md` must be reviewed individually — the high-level "is this page relevant?" question hides individual matches.
+10. **Mandatory:** Run the [stale count sweep](_shared/procedures/stale-count-sweep.md). This is a first-class regression class — do not skip. The common-offender list and grep patterns live in the fragment; apply them against the pre-ingest count (N) and the post-ingest count (N+1 or N+k). When complete, return here and continue with step 11.
+11. Append an entry to `wiki/log.md`.
+12. Report the outcome to the user: pages created, pages updated, and any contradictions found.
+13. **Commit and push.** Run [commit and push](_shared/procedures/commit-and-push.md) in full. The fragment owns the research-vs-workflow split, the explicit-path staging discipline, the `Co-Authored-By` trailer requirement, and the feature-branch + PR rule for any workflow file changes.
 
 ## Completion Checklist
 
-- The source page exists in the correct `wiki/sources/` location.
-- All relevant entity and concept pages were updated or created.
-- `wiki/index.md` reflects the new pages **and** all directory-tree counts (sources, entities, MOCs, analyses, concepts) are updated.
-- Relevant MOCs include the new reading path entries.
-- `raw/index.md` and `raw/download_arxiv_papers.py` were updated if needed.
-- `raw/checklist.md` includes a new row for the ingested paper, with `raw/pdf/...` (not `reference/...`) paths and any venue-duplicate refs.
-- Every numbered direction in `frontier-research-directions.md` and every numbered tension in `contradictions.md` was reviewed individually (not just the page as a whole).
-- All living analyses reviewed per `_shared/procedures/living-analyses-review.md`.
-- Stale count sweep performed per `_shared/procedures/stale-count-sweep.md` — every common-offender file re-verified by name.
-- `README.md` badge counts, paragraph text, and per-thread `(N papers)` summary headers all reflect the new count.
-- `wiki/log.md` includes the ingest entry.
+- All items in [`_shared/checklists/base.md`](_shared/checklists/base.md) hold.
+- All items in [`_shared/checklists/ingest-additions.md`](_shared/checklists/ingest-additions.md) hold.
 
 ## Related Workflows
 

--- a/workflows/lint.md
+++ b/workflows/lint.md
@@ -104,9 +104,10 @@ Use this workflow when you need to audit the wiki for quality issues, especially
    - Grep `raw/checklist.md` for `reference/pdf/` and `reference/latex/`. Zero matches are required — these are stale historical paths from a directory move and must be rewritten to `raw/pdf/...` / `raw/latex/...`.
    - For each canonical PDF arxiv ID in `raw/index.md`, confirm a matching row exists in `raw/checklist.md` (match by arxiv ID in either the "Original refs from list" column or the "Local PDF" path). Flag any arxiv IDs present in `raw/index.md` but missing from `raw/checklist.md`, and any rows in `raw/checklist.md` whose arxiv ID is not in `raw/index.md`.
 5. Run the **Redundancy & Dead-Reference Audit** (see section below). This is a four-class sub-pass that catches phantom raw assets, source-page ↔ raw asset bijection breaks, slug collisions, and MOC/concept overlap.
-6. Report findings and suggest fixes.
-7. Apply fixes only after user approval.
-8. Log the lint pass in `wiki/log.md`.
+6. **Terminology drift scan.** Grep for the drift variants enumerated in [glossary](_shared/glossary.md) and add them to the findings list. Do not silently rewrite — drift variants surface as findings so the user sees the pattern.
+7. Report findings and suggest fixes.
+8. Apply fixes only after user approval.
+9. Log the lint pass in `wiki/log.md`.
 
 ## Redundancy & Dead-Reference Audit
 
@@ -136,7 +137,7 @@ When two source pages share a leading filename token (e.g., `kvcomm-*`, `coconut
 
 1. `Glob wiki/sources/**/*.md` and group basenames by their first hyphenated token.
 2. For any group with size ≥ 2 from different papers, suggest a hybrid rename: `<technique>-<institution>-<distinguisher>.md` (e.g., `kvcomm-kth-selective.md` vs `kvcomm-duke-online-reuse.md`).
-3. Renames are bulk operations — see "Bulk source-page rename" below.
+3. Renames are bulk operations — run [bulk source rename](_shared/procedures/bulk-source-rename.md) for each rename. The fragment owns the `git mv` + `sed` + verify sequence and is the only context where `sed` is the blessed tool.
 
 ### D. MOC and concept overlap
 
@@ -146,27 +147,12 @@ Two MOCs are redundant when one defers to the other for its primary content. Two
 2. For any MOC whose body section is duplicated in another MOC, propose collapsing it to the unique scaffolding (cross-cutting concepts, key entities, theoretical foundations) and adding a one-line pointer to the canonical source.
 3. For concept-page overlap, prefer keeping the synthesis page and folding the duplicate into a section anchor.
 
-## Bulk source-page rename
-
-When option **C** above triggers (or any other rename of a source page slug), follow this exact sequence to keep all backlinks consistent. **Do not** edit one file at a time — the surface area is large enough that a single missed link breaks navigation.
-
-1. **Enumerate references first**: `Grep '\[\[<old-slug>' .` — confirm the count and the files affected.
-2. **Move the file with `git mv`** so history is preserved. Never use `Write` to create a new file alongside the old.
-3. **Bulk rewrite all references**. The blessed tool for this single case is `sed` (the only place where `sed` overrides the "use Edit, not sed" default), because (a) the slug is unique enough that collateral damage is impossible to introduce, and (b) the alternative is 30+ Read+Edit pairs:
-
-   ```bash
-   find wiki raw -name "*.md" -print0 | xargs -0 sed -i 's/<old-slug>/<new-slug>/g'
-   ```
-
-4. **Verify**: re-run `Grep '<old-slug>' .` — must return zero matches.
-5. **Update `raw/index.md`** if the source page is also referenced there (the sed pass usually handles this — confirm).
-6. **Log it** in `wiki/log.md` with action `lint` or `update`, listing both the old and new slugs.
-
 ## Completion Checklist
+- All items in [`_shared/checklists/base.md`](_shared/checklists/base.md) hold.
+- All items in [`_shared/checklists/audit-additions.md`](_shared/checklists/audit-additions.md) hold.
 - Findings are grouped by content vs structural issues.
 - Proposed fixes are specific and actionable.
-- No files were edited without approval.
-- The lint pass is logged in `wiki/log.md` after changes are made.
+- Terminology drift findings (if any) are in the report.
 
 ## Related Workflows
 - `workflows/query.md`

--- a/workflows/moc-gap-analysis.md
+++ b/workflows/moc-gap-analysis.md
@@ -91,21 +91,18 @@ Use this workflow when the task sounds like:
    - reading path outline
    - connections to existing MOCs
 7. Get user approval, then create.
-8. Use parallel subagents if creating 2+ MOCs.
-9. Ensure each subagent creates only its own MOC file.
-10. Do not let subagents update shared files.
-11. Consolidate shared files after completion:
-   - `index.md`
-   - `log.md`
-- AGENTS.md Current MOCs list
-12. Run Verification on each new MOC.
+8. **If creating 2+ MOCs, dispatch them under the parallel subagent protocol.** Run [parallel subagent protocol](_shared/procedures/parallel-subagent-protocol.md) in full, then return here and continue with step 9. The fragment owns scope boundaries (each subagent creates only its own MOC file), the canonical coordinator-only file enumeration, and the report-not-edit instruction. For a single MOC, skip the parallel dispatch and create the file directly.
+9. **Spot-check the agent output.** Run [spot check agent output](_shared/procedures/spot-check-agent-output.md), then return here and continue with step 10. Skipped if step 8 was skipped (single-MOC case).
+10. **Consolidate the coordinator-only files.** Run [update index and assets](_shared/procedures/update-index-and-assets.md) — the fragment's directory-tree update covers the new MOC count, and the entry-list update covers the new MOC's row. The `AGENTS.md` Current MOCs list sync is part of the fragment's verification step.
+11. Run `workflows/verification.md` on each new MOC.
+12. **Commit and push.** Run [commit and push](_shared/procedures/commit-and-push.md) in full.
 
 ## Completion Checklist
+- All items in [`_shared/checklists/base.md`](_shared/checklists/base.md) hold.
+- All items in [`_shared/checklists/audit-additions.md`](_shared/checklists/audit-additions.md) hold (this is a navigation audit even though it produces new MOC files — the audit additions cover the parallel-subagent and spot-check discipline).
 - MOC gaps are identified and prioritized.
-- Each proposed MOC has a clear title and reading path.
-- Shared files are not modified by subagents.
-- Consolidation is planned for `index.md`, `log.md`, and the AGENTS.md MOCs list.
-- Verification is queued for each created MOC.
+- Each created MOC has a clear title and reading path with the ordering principle stated in the header.
+- Verification has been run on each created MOC.
 
 ## Related Workflows
 - `workflows/verification.md`

--- a/workflows/plugin-audit.md
+++ b/workflows/plugin-audit.md
@@ -69,17 +69,18 @@ Use this workflow when the task sounds like:
 1. Inventory plugins by reading `.obsidian/community-plugins.json` and each plugin's `manifest.json` and `data.json`.
 2. For each plugin, check compliance:
    - LaTeX Suite / Extended MathJax: scan all wiki pages for unwrapped math, Unicode math symbols such as `∈`, `ℝ`, and `≈`, plaintext subscripts like `h_T`, or expressions outside `$...$` delimiters. Convert any found.
-   - Pandoc: verify all pages have `title:` in frontmatter.
+   - Pandoc: run [verify frontmatter completeness](_shared/procedures/verify-frontmatter-completeness.md) on a sample of pages, then return here. The universal-minimum check covers the `title:` requirement; the fragment is the canonical schema.
    - Preamble: check that macros in `preamble.sty` are used consistently, with no raw `\mathbb{R}` when `\R` is available.
    - Diagrams: check for ASCII art in code blocks that should be Mermaid. Check for `.drawio` files, which should not exist. Check for `\n` inside Mermaid node labels — replace with `<br>`. Check for math notation (subscripts, superscripts, LaTeX-like expressions) in Mermaid node labels — these should use the side-by-side notation pattern (`[!diagram|left]` + `[!notation|right]` callouts) per AGENTS.md §Diagram Maintenance rule 6.
-3. Bulk fix any issues found using parallel subagents, one per file group.
+3. **Bulk fix any issues found using parallel subagents.** Run [parallel subagent protocol](_shared/procedures/parallel-subagent-protocol.md) in full, then return here and continue with step 4. The fragment owns scope boundaries (one agent per file group) and the canonical coordinator-only file enumeration.
 4. Log the audit in `wiki/log.md`.
 
 ## Completion Checklist
+- All items in [`_shared/checklists/base.md`](_shared/checklists/base.md) hold.
+- All items in [`_shared/checklists/audit-additions.md`](_shared/checklists/audit-additions.md) hold.
 - Plugin inventory has been checked.
 - Math, frontmatter, diagram, and preamble compliance have been scanned.
 - Any fixes are grouped by file family, not mixed across unrelated files.
-- The audit is logged in `wiki/log.md`.
 
 ## Related Workflows
 - `workflows/review.md`

--- a/workflows/review.md
+++ b/workflows/review.md
@@ -83,30 +83,30 @@ Common triggers include:
 1. Run the full lint checklist:
    - contradictions, orphans, red links, stale claims, and missing cross-references
    - file placement, path references, and count accuracy
-2. Spot-check that all pages have required frontmatter fields:
-   - `type`, `title`, `created`
-   - `source_file` and `latex_source` for source pages
+2. **Spot-check frontmatter completeness on a sample of pages.** Run [verify frontmatter completeness](_shared/procedures/verify-frontmatter-completeness.md) on the sample, then return here. The fragment is the canonical schema; the per-type field lists live there, not here.
 3. Verify all source pages have the `## Source Materials` footer.
 4. Identify pages below the depth standard and flag them for expansion.
 5. Check MOC coverage:
    - all major themes have MOCs
    - MOCs are current
-- the `AGENTS.md` MOC list is in sync
+   - the `AGENTS.md` MOC list is in sync
 6. Check whether `overview-state-of-field.md` needs updating using the documented triggers.
 7. Verify `AGENTS.md` directory structure, path conventions, and workflow steps still match the actual vault layout.
 8. If the vault was reorganized, ensure all path references across `AGENTS.md`, `README.md`, index files, and `raw/index.md` are updated.
-9. Report all findings.
-10. Apply fixes only with user approval.
-11. Log the review in `wiki/log.md`.
+9. **Terminology drift scan.** Grep for the drift variants enumerated in [glossary](_shared/glossary.md) and add them to the findings list. Do not silently rewrite — drift variants surface as findings so the user sees the pattern.
+10. Report all findings.
+11. Apply fixes only with user approval.
+12. Log the review in `wiki/log.md`.
 
 ## Completion Checklist
+- All items in [`_shared/checklists/base.md`](_shared/checklists/base.md) hold.
+- All items in [`_shared/checklists/audit-additions.md`](_shared/checklists/audit-additions.md) hold.
 - Lint findings are reported.
 - Frontmatter and source-material coverage are checked.
 - Depth gaps are identified.
 - MOC coverage and overview freshness are checked.
 - Schema and path consistency are verified.
-- Fixes are only applied after approval.
-- The review is logged in `wiki/log.md`.
+- Terminology drift findings (if any) are in the report.
 
 ## Related Workflows
 - `Lint` for a narrower health check.

--- a/workflows/synthesize.md
+++ b/workflows/synthesize.md
@@ -98,16 +98,16 @@ Create cross-cutting analysis pages that connect multiple sources and concepts i
    - Collaboration strategy for external engagement opportunities.
    - Benchmark overlap for coverage matrices and blind spots across papers.
 4. Create the analysis page with citations to all relevant sources.
-5. Update `wiki/index.md` and any relevant MOCs.
-6. Append the work to `wiki/log.md`.
+5. **Sync indexes and assets.** Run [update index and assets](_shared/procedures/update-index-and-assets.md) in full, then return here and continue with step 6. The fragment owns the `wiki/index.md` directory-tree count and entry-list update for the new analysis page.
+6. **Update affected MOC reading paths.** For each MOC whose theme the new analysis touches, run [moc update](_shared/procedures/moc-update.md). Skip if no MOC is affected (a synthesis page that creates a new theme may need no immediate MOC update).
+7. Append the work to `wiki/log.md`.
+8. **Commit and push.** Run [commit and push](_shared/procedures/commit-and-push.md) in full.
 
 ## Completion Checklist
 
+- All items in [`_shared/checklists/base.md`](_shared/checklists/base.md) hold.
 - The analysis type matches the synthesis problem.
 - The page cites all relevant source and concept pages.
-- `wiki/index.md` reflects the new or updated analysis page.
-- Relevant MOCs point to the new reading path.
-- `wiki/log.md` records the change.
 
 ## Related Workflows
 

--- a/workflows/verification.md
+++ b/workflows/verification.md
@@ -82,24 +82,27 @@ Quality-assurance pass for work done by parallel subagents. Use it to catch stru
 1. Treat subagent output as suspect until checked. Subagents work in isolation and commonly make mistakes such as wrong file paths, imprecise claims, numbers off by small amounts, or conflated findings from different papers.
 2. Run the **structural check** directly as the coordinator:
    - Confirm files are in the correct directories, such as `wiki/` rather than the vault root, and the correct `sources/` subdirectory when relevant.
-   - Confirm frontmatter is complete and consistent with existing pages, including `title:` and the correct `type:`.
-- Confirm `AGENTS.md`'s Current MOCs list matches the actual `wiki/mocs/*.md` files.
-3. Run the **content accuracy check** in parallel, one review subagent per created page:
-   - Each review agent reads the created page and every source page it references.
+   - Run [verify frontmatter completeness](_shared/procedures/verify-frontmatter-completeness.md) on each created page, then return here. The fragment is the canonical schema; per-type field lists live there.
+   - Confirm `AGENTS.md`'s Current MOCs list matches the actual `wiki/mocs/*.md` files.
+3. **Spot-check the agent output as a lightweight first pass.** Run [spot check agent output](_shared/procedures/spot-check-agent-output.md), then return here and continue with step 4. If the spot check finds 0–1 issues, the heavyweight per-page review in step 4 may still find more — run it. If the spot check finds 2+ issues, the parallel phase's output is suspect at scale and step 4 is mandatory before any consolidation downstream.
+4. **Run the content accuracy check in parallel**, one read-only review subagent per created page. Dispatch the review agents under [parallel subagent protocol](_shared/procedures/parallel-subagent-protocol.md), then return here and continue with step 5. Verification's review agents are a special case — they read pages and return findings, never edit; the protocol fragment documents this special case in its invariants. Each review agent's task:
+   - Read the created page and every source page it references.
    - Cross-check author names, venues, years, specific numbers, and method descriptions.
    - Verify `[[wiki-links]]` targets exist and match the described content.
    - Flag overstatements, including editorial synthesis presented as direct findings, cherry-picked peak numbers without context, or conflated findings from different papers.
    - Flag missing coverage, including relevant pages that should have been included but were not.
    - Return findings only, with suggested fixes written as exact `old -> new` text where possible.
-4. Collect review findings only; do not let review agents make edits.
-5. Apply fixes in priority order: factual errors, overstatements, missing coverage, then style.
-6. Log the verification pass in `wiki/log.md`.
+5. Collect review findings only; do not let review agents make edits.
+6. Apply fixes in priority order: factual errors, overstatements, missing coverage, then style.
+7. Log the verification pass in `wiki/log.md`.
 
 ## Completion Checklist
+- All items in [`_shared/checklists/base.md`](_shared/checklists/base.md) hold.
+- All items in [`_shared/checklists/audit-additions.md`](_shared/checklists/audit-additions.md) hold.
 - Structural checks are clean.
 - Review agents have read the created pages and their source references.
 - All reported errors have been prioritized and fixed.
-- `wiki/log.md` has a verification entry.
+- The spot check passed (or escalated to the full per-page review, which then completed).
 
 ## Related Workflows
 - `workflows/batch-ingest.md`


### PR DESCRIPTION
Third slice of the workflows/ deduplication tracked in #7. With this PR, every fragment introduced in #14 has at least one real caller and the inlined drift it was designed to eliminate is gone from the workflows tree.

## Summary

- **12 workflows rewired** to call the 14 PR 2a fragments (~30 call sites). Net diff: **+261 / −265** across the workflows tree — fragment calls are denser than the inlined text they replace.
- **3 new checklist fragments** under \`workflows/_shared/checklists/\`: \`base.md\`, \`ingest-additions.md\`, \`audit-additions.md\`. Workflow Completion Checklists are rewritten to compose from these instead of duplicating fragment invariants.
- **CONVENTIONS.md glossary seed dropped** in favor of a one-line pointer to \`_shared/glossary.md\`. Keeping the seed alongside the fragment guaranteed future drift between the two.
- **\`(expected, PR 2b)\` markers stripped** from every fragment's \`## Used by\` footer. Footers are now the authoritative caller list.

## Per-workflow rewiring summary

| Workflow | Fragment calls added | Notable changes |
|---|---|---|
| \`ingest.md\` | 5 | Steps 7+9+10 collapse into \`update-index-and-assets\`; new \`moc-update\` at step 8; Procedure shrinks from 15 to 13 steps; Completion Checklist rewritten to compose from \`base\` + \`ingest-additions\` |
| \`gap-analysis.md\` | 3 | Phase 6 collapses from ~25 lines to a \`commit-and-push\` call; the long-form was the canonical source for that fragment |
| \`batch-ingest.md\` | 5 | Required Context off-limits enumeration (drifted from other workflows) repoints to the rule fragment; consolidation pass now uses 4 fragments |
| \`enrichment-audit.md\` | 4 | Phase 3's drifted 4-item shared-file list is gone — replaced by \`parallel-subagent-protocol\`'s call to the canonical rule |
| \`moc-gap-analysis.md\` | 4 | Steps 8-11 collapse into protocol + spot-check + index-and-assets + commit-and-push |
| \`verification.md\` | 3 | Step 2 frontmatter check uses fragment; new spot-check pass before per-page review |
| \`enrich.md\` | 4 | Index/raw/downloader sync collapses; adds \`bulk-source-rename\` pointer for slug renames |
| \`review.md\` | 2 | Frontmatter spot-check uses fragment; new step 9 adds terminology drift scan against glossary |
| \`synthesize.md\` | 3 | Step 5 splits into \`update-index-and-assets\` + \`moc-update\`; adds \`commit-and-push\` |
| \`lint.md\` | 2 | Inlined "Bulk source-page rename" section deleted; new step 6 adds terminology drift scan |
| \`plugin-audit.md\` | 2 | Pandoc check uses \`verify-frontmatter-completeness\`; bulk-fix uses \`parallel-subagent-protocol\` |

## Drift reconciliation evidence

The four highest-leverage drift cases identified in #7's audit are now resolved on master:

| Drift | Before | After |
|---|---|---|
| Off-limits file enumeration | 4 different lists in \`batch-ingest\` (6 items, includes \`AGENTS.md\`), \`enrichment-audit\` (4 items, missing \`raw/index.md\`), \`moc-gap-analysis\` (3 items, missing both), \`verification\` (no enumeration) | All four now reference \`_shared/rules/shared-file-off-limits.md\`'s 12-item canonical list via \`parallel-subagent-protocol\` |
| Frontmatter check fields | \`ingest\` listed 9 fields, \`review\` listed 5, \`plugin-audit\` checked only \`title:\`, \`verification\` checked 2 | All four now reference \`_shared/procedures/verify-frontmatter-completeness.md\`, which references the canonical \`_shared/rules/frontmatter-schema.md\` |
| Index/raw/downloader sync ordering | 5 different sub-step orderings across \`ingest\`, \`batch-ingest\`, \`enrich\`, \`synthesize\`, \`enrichment-audit\` | All five now call \`_shared/procedures/update-index-and-assets.md\` |
| commit-and-push procedure | Long form inlined in \`gap-analysis\` Phase 6, one-line gesture in \`ingest\` step 15 | Both reference \`_shared/procedures/commit-and-push.md\`; added to \`batch-ingest\`, \`enrich\`, \`synthesize\`, \`enrichment-audit\`, \`moc-gap-analysis\` |

## Verification done before opening this PR

Greps confirm the inlined fragment text is gone from the workflows tree:

- \`Stale paper-count sweep\` / \`Common offenders to check by name\` / \`eight columns: \\`Paper\` → only inside \`_shared/procedures/stale-count-sweep.md\` and \`_shared/procedures/raw-checklist-row.md\`.
- \`git checkout -b workflow-\` → only inside \`_shared/procedures/commit-and-push.md\`.
- \`shared files are off-limits\` / \`Do not let subagents update shared files\` / \`Keep shared files off-limits\` → zero matches anywhere.
- \`find wiki raw -name\` / \`xargs -0 sed\` → only inside \`_shared/procedures/bulk-source-rename.md\`.

## What's not in this PR (deferred to PR 3)

- Phase-based directory reorganization (\`create/\`, \`enrich/\`, \`audit/\`, \`query/\`, \`meta/\`).
- AGENTS.md path-reference updates (depends on PR 3's moves).
- README.md and MOC-page workflow path updates (depends on PR 3's moves).

## Test plan

- [ ] Walk \`ingest.md\` end-to-end as if executing the workflow. Confirm no load-bearing invariant from the old steps 7/9/10 is lost.
- [ ] Walk \`gap-analysis.md\` Phase 6 and confirm \`commit-and-push\` covers everything the old inline phase did (this is the highest-risk collapse — Phase 6 used to be the canonical source).
- [ ] Walk \`batch-ingest.md\` and confirm the new step 3 spot-check + step 5 verification ordering is correct (lightweight first, heavyweight second).
- [ ] Open \`enrichment-audit.md\` Phase 3 and confirm there is no longer an inlined off-limits file list — only the protocol fragment call. This was the highest-drift inline list (missing \`raw/index.md\` and \`AGENTS.md\`).
- [ ] Render \`workflows/CONVENTIONS.md\` and confirm the seed glossary table is gone and the pointer to \`_shared/glossary.md\` is in its place.
- [ ] Open all 14 fragment \`## Used by\` footers and confirm no \`(expected, PR 2b)\` markers remain.
- [ ] Run the verification greps from the Summary above and confirm they still hold post-merge.

Refs #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)